### PR TITLE
AGL-1635: timezones added to timestamps

### DIFF
--- a/modules/client-java/src/test/java/be/wegenenverkeer/atom/java/FeedProcessorTest.java
+++ b/modules/client-java/src/test/java/be/wegenenverkeer/atom/java/FeedProcessorTest.java
@@ -3,7 +3,7 @@ package be.wegenenverkeer.atom.java;
 import be.wegenenverkeer.atom.EntryRef;
 import be.wegenenverkeer.atom.FeedProcessingException;
 import be.wegenenverkeer.atom.Url;
-import org.joda.time.LocalDateTime;
+import org.joda.time.DateTime;
 import org.junit.Test;
 import scala.Option;
 
@@ -112,7 +112,7 @@ public class FeedProcessorTest {
                     FEED_URL,
                     "Blabla",
                     null,
-                    new LocalDateTime(),
+                    new DateTime(),
                 feedLinks,
                     entries
             );

--- a/modules/client-play/src/main/scala/be/wegenenverkeer/atom/providers/PlayWsFeedProvider.scala
+++ b/modules/client-play/src/main/scala/be/wegenenverkeer/atom/providers/PlayWsFeedProvider.scala
@@ -3,7 +3,7 @@ package be.wegenenverkeer.atom.providers
 import be.wegenenverkeer.atom._
 import be.wegenenverkeer.atom.async.AsyncFeedProvider
 import com.typesafe.scalalogging.slf4j.Logging
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 import play.api.http.HeaderNames
 import play.api.libs.ws.WSClient
 
@@ -63,7 +63,7 @@ class PlayWsFeedProvider[T](feedUrl:String,
               base = Url(pageUrl),
               title = None,
               generator = None,
-              updated = new LocalDateTime(),
+              updated = new DateTime(),
               links = List(Link(Link.selfLink, Url(pageUrl))),
               entries = Nil
             )

--- a/modules/client-play/src/test/scala/be/wegenenverkeer/atom/providers/PlayWsFeedProviderTest.scala
+++ b/modules/client-play/src/test/scala/be/wegenenverkeer/atom/providers/PlayWsFeedProviderTest.scala
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.core.`type`.TypeReference
 import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.datatype.joda.JodaModule
 import mockws._
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 import play.api.http.MimeTypes
 import play.api.mvc.Action
@@ -92,7 +92,7 @@ class PlayWsFeedProviderTest extends FunSuite with Matchers with FeedUnmarshalle
     }
   }
 
-  val updated = Adapters.outputFormatterWithSecondsAndOptionalTZ.print(new LocalDateTime())
+  val updated = Adapters.outputFormatterWithSecondsAndOptionalTZ.print(new DateTime())
 
   val page1: String = """{
                         |  "base" : "http://example.com",

--- a/modules/client-scala/src/test/scala/be/wegenenverkeer/atom/FeedIteratorFixture.scala
+++ b/modules/client-scala/src/test/scala/be/wegenenverkeer/atom/FeedIteratorFixture.scala
@@ -1,7 +1,7 @@
 package be.wegenenverkeer.atom
 
 import be.wegenenverkeer.atom.FeedEntryIterator.Implicits._
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 import scala.util.{Success, Try}
 
@@ -155,7 +155,7 @@ trait FeedIteratorFixture[E] {
           base = Url(baseUrl),
           title = Option("title"),
           generator = None,
-          updated = new LocalDateTime(),
+          updated = new DateTime(),
           links = links,
           entries = List()
         )

--- a/modules/format-java/src/main/java/be/wegenenverkeer/atom/java/Adapters.java
+++ b/modules/format-java/src/main/java/be/wegenenverkeer/atom/java/Adapters.java
@@ -1,6 +1,6 @@
 package be.wegenenverkeer.atom.java;
 
-import org.joda.time.LocalDateTime;
+import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
 import org.joda.time.format.ISODateTimeFormat;
@@ -14,16 +14,16 @@ public class Adapters {
             .appendTimeZoneOffset("Z", true, 2, 4)
             .toFormatter();
 
-    public static class AtomDateTimeAdapter extends XmlAdapter<String, LocalDateTime> {
+    public static class AtomDateTimeAdapter extends XmlAdapter<String, DateTime> {
 
         @Override
-        public LocalDateTime unmarshal(String v) throws Exception {
-            return outputFormatterWithSecondsAndOptionalTZ.parseDateTime(v).toLocalDateTime();
+        public DateTime unmarshal(String v) throws Exception {
+            return outputFormatterWithSecondsAndOptionalTZ.parseDateTime(v).toDateTime();
         }
 
         @Override
-        public String marshal(LocalDateTime v) throws Exception {
-            return outputFormatterWithSecondsAndOptionalTZ.print(v.toDateTime());
+        public String marshal(DateTime v) throws Exception {
+            return outputFormatterWithSecondsAndOptionalTZ.print(v);
         }
     }
 

--- a/modules/format-java/src/main/java/be/wegenenverkeer/atom/java/Entry.java
+++ b/modules/format-java/src/main/java/be/wegenenverkeer/atom/java/Entry.java
@@ -1,6 +1,6 @@
 package be.wegenenverkeer.atom.java;
 
-import org.joda.time.LocalDateTime;
+import org.joda.time.DateTime;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -16,7 +16,7 @@ public final class Entry<T> {
     private String id;
 
     @XmlElement @XmlJavaTypeAdapter(Adapters.AtomDateTimeAdapter.class)
-    LocalDateTime updated;
+    DateTime updated;
 
     @XmlElement
     private Content<T> content;
@@ -36,10 +36,10 @@ public final class Entry<T> {
     }
 
     public Entry(String id, Content<T> content, List<Link> links) {
-        this(id, new LocalDateTime(), content, links);
+        this(id, new DateTime(), content, links);
     }
 
-    public Entry(String id, LocalDateTime updated, Content<T> content, List<Link> links) {
+    public Entry(String id, DateTime updated, Content<T> content, List<Link> links) {
         this.id = id;
         this.updated = updated;
         this.content = content;
@@ -54,11 +54,11 @@ public final class Entry<T> {
         this.id = id;
     }
 
-    public LocalDateTime getUpdated() {
+    public DateTime getUpdated() {
         return updated;
     }
 
-    public void setUpdated(LocalDateTime updated) {
+    public void setUpdated(DateTime updated) {
         this.updated = updated;
     }
 

--- a/modules/format-java/src/main/java/be/wegenenverkeer/atom/java/Feed.java
+++ b/modules/format-java/src/main/java/be/wegenenverkeer/atom/java/Feed.java
@@ -1,7 +1,7 @@
 package be.wegenenverkeer.atom.java;
 
 import be.wegenenverkeer.atom.java.Adapters.AtomDateTimeAdapter;
-import org.joda.time.LocalDateTime;
+import org.joda.time.DateTime;
 
 import javax.xml.bind.annotation.*;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
@@ -19,13 +19,13 @@ public final class Feed<T> {
     public Feed() {
     }
 
-    public Feed(String id, String base, String title, Generator generator, LocalDateTime updated) {
+    public Feed(String id, String base, String title, Generator generator, DateTime updated) {
         this(id, base, title, generator, updated, new ArrayList<Link>(), new ArrayList<Entry<T>>());
     }
 
 
     public Feed(String id, String base, String title, Generator generator,
-                LocalDateTime updated, List<Link> links, List<Entry<T>> entries) {
+                DateTime updated, List<Link> links, List<Entry<T>> entries) {
         this.id = id;
         this.base = base;
         this.title = title;
@@ -48,7 +48,7 @@ public final class Feed<T> {
     private Generator generator;
 
     @XmlElement @XmlJavaTypeAdapter(AtomDateTimeAdapter.class)
-    private LocalDateTime updated;
+    private DateTime updated;
 
     @XmlElement(name = "link")
     private List<Link> links = new ArrayList<Link>();
@@ -88,11 +88,11 @@ public final class Feed<T> {
         this.generator = generator;
     }
 
-    public LocalDateTime getUpdated() {
+    public DateTime getUpdated() {
         return updated;
     }
 
-    public void setUpdated(LocalDateTime updated) {
+    public void setUpdated(DateTime updated) {
         this.updated = updated;
     }
 

--- a/modules/format-java/src/test/java/be/wegenenverkeer/atom/java/FeedSerializationTest.java
+++ b/modules/format-java/src/test/java/be/wegenenverkeer/atom/java/FeedSerializationTest.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
-import org.joda.time.LocalDateTime;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,13 +54,13 @@ public class FeedSerializationTest {
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
         jaxbContext = JAXBContext.newInstance(Feed.class, Link.class, Customer.class);
 
-        LocalDateTime LocalDateTime = new LocalDateTime().withMillisOfSecond(0);
+        DateTime dateTime = new DateTime().withMillisOfSecond(0);
 
         stringsFeed = new Feed("urn:id:"+ UUID.randomUUID().toString(),
                 "http://www.example.org",
                 "strings of life",
                 null,
-                LocalDateTime);
+                dateTime);
         stringsFeed.getLinks().add(new Link("self", "foo"));
         stringsFeed.getEntries().add(new Entry("id1", new Content<String>("foo", "text/plain")));
         stringsFeed.getEntries().add(new Entry("id2", new Content<String>("<html><p>bla</p></html>", "text/html"))); //this will be escaped in xml but not in json
@@ -71,13 +71,13 @@ public class FeedSerializationTest {
                 "http://www.example.org",
                 "customers",
                 new Generator("atomium", "http://github.com/WegenenVerkeer/atomium", "0.0.1"),
-                LocalDateTime);
+                dateTime);
         customersFeed.getLinks().add(new Link("self", "foo"));
         customersFeed.getEntries().add(new Entry("id", new Content(customer, "application/xml")));
 
         jaxbElementFeed = new Feed();
         jaxbElementFeed.setId("urn:id:" + UUID.randomUUID().toString());
-        jaxbElementFeed.setUpdated(LocalDateTime);
+        jaxbElementFeed.setUpdated(dateTime);
         JAXBElement<Integer> jaxbElement = new JAXBElement<Integer>(new QName("http://www.w3.org/2001/XMLSchema-instance", "int"), Integer.class, 999);
         jaxbElementFeed.getEntries().add(new Entry("id1", new Content(jaxbElement, "application/xml")));
         JAXBElement<Integer> jaxbElement2 = new JAXBElement<Integer>(new QName("http://www.w3.org/2001/XMLSchema-instance", "int"), Integer.class, 1010);

--- a/modules/format/src/main/scala/be/wegenenverkeer/atom/Entry.scala
+++ b/modules/format/src/main/scala/be/wegenenverkeer/atom/Entry.scala
@@ -1,6 +1,6 @@
 package be.wegenenverkeer.atom
 
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 /**
  * Representation of an entry in an Atom feed. The entry acts as a container for metadata and data associated with the
@@ -12,4 +12,4 @@ import org.joda.time.LocalDateTime
  * @param links links associated with this entry
  * @tparam T the type of entry
  */
-case class Entry[+T](id: String, updated: LocalDateTime, content: Content[T], links: List[Link])
+case class Entry[+T](id: String, updated: DateTime, content: Content[T], links: List[Link])

--- a/modules/format/src/main/scala/be/wegenenverkeer/atom/Feed.scala
+++ b/modules/format/src/main/scala/be/wegenenverkeer/atom/Feed.scala
@@ -4,7 +4,7 @@ import _root_.java.net.URI
 import _root_.java.security.MessageDigest
 import _root_.java.math.BigInteger
 
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 /**
  * Representation of a (page in an) Atom feed.
@@ -22,7 +22,7 @@ case class Feed[+T](id: String,
                    base: Url,
                    title: Option[String],
                    generator: Option[Generator] = None,
-                   updated: LocalDateTime,
+                   updated: DateTime,
                    links: List[Link],
                    entries: List[Entry[T]],
                    headers: Map[String, String] = Map.empty) {

--- a/modules/server-jdbc/src/main/scala/be/wegenenverkeer/atom/AbstractJdbcFeedStore.scala
+++ b/modules/server-jdbc/src/main/scala/be/wegenenverkeer/atom/AbstractJdbcFeedStore.scala
@@ -1,7 +1,7 @@
 package be.wegenenverkeer.atom
 
 import be.wegenenverkeer.atom.jdbc.{EntryDbModel, Dialect}
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 abstract class AbstractJdbcFeedStore[E](context: JdbcContext,
                                         feedName: String,
@@ -74,14 +74,14 @@ abstract class AbstractJdbcFeedStore[E](context: JdbcContext,
    * @param entries the entries to push to the feed
    */
   override def push(entries: Iterable[E]): Unit = {
-    val timestamp: LocalDateTime = new LocalDateTime()
+    val timestamp: DateTime = new DateTime()
     entries foreach { entry =>
       dialect.addFeedEntry(entryTableName, EntryDbModel(sequenceNo = None, generateEntryID, value = ser(entry), timestamp = timestamp))
     }
   }
 
   override def push(uuid: String, entry: E): Unit = {
-    val timestamp: LocalDateTime = new LocalDateTime()
+    val timestamp: DateTime = new DateTime()
     dialect.addFeedEntry(entryTableName, EntryDbModel(sequenceNo = None, uuid, value = ser(entry), timestamp = timestamp))
   }
 

--- a/modules/server-jdbc/src/main/scala/be/wegenenverkeer/atom/jdbc/Dialect.scala
+++ b/modules/server-jdbc/src/main/scala/be/wegenenverkeer/atom/jdbc/Dialect.scala
@@ -3,7 +3,7 @@ package be.wegenenverkeer.atom.jdbc
 import java.sql._
 
 import be.wegenenverkeer.atom.JdbcContext
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 trait Dialect {
 
@@ -129,7 +129,7 @@ trait Dialect {
           d match {
             case stringData: String => preparedStatement.setString(index, stringData)
             case intData: Int => preparedStatement.setInt(index, intData)
-            case timeData: LocalDateTime => preparedStatement.setTimestamp(index, new Timestamp(timeData.toDate.getTime))
+            case timeData: DateTime => preparedStatement.setTimestamp(index, new Timestamp(timeData.toDate.getTime))
             case _ => throw new SQLDataException("Unknown data type used in the atomium feed generator.")
           }
           setPreparedData(ds, index + 1)

--- a/modules/server-jdbc/src/main/scala/be/wegenenverkeer/atom/jdbc/EntryDbModel.scala
+++ b/modules/server-jdbc/src/main/scala/be/wegenenverkeer/atom/jdbc/EntryDbModel.scala
@@ -2,7 +2,7 @@ package be.wegenenverkeer.atom.jdbc
 
 import java.sql.ResultSet
 
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 /**
  * The entry model as it is stored in the DB.
@@ -13,7 +13,7 @@ import org.joda.time.LocalDateTime
  * @param value The actual data stored in the entry, serialized as a sring.
  * @param timestamp The time this entry was created and stored.
  */
-case class EntryDbModel(sequenceNo: Option[Long], uuid: String, value: String, timestamp: LocalDateTime)
+case class EntryDbModel(sequenceNo: Option[Long], uuid: String, value: String, timestamp: DateTime)
 
 object EntryDbModel {
 
@@ -21,7 +21,7 @@ object EntryDbModel {
     sequenceNo = Some(rs.getLong(EntryDbModel.Table.idColumn)),
     uuid = rs.getString(EntryDbModel.Table.uuidColumn),
     value = rs.getString(EntryDbModel.Table.valueColumn),
-    timestamp = new LocalDateTime(rs.getDate(EntryDbModel.Table.timestampColumn))
+    timestamp = new DateTime(rs.getDate(EntryDbModel.Table.timestampColumn))
   )
 
   object Table {

--- a/modules/server-mongo/src/main/scala/be/wegenenverkeer/atom/MongoFeedStore.scala
+++ b/modules/server-mongo/src/main/scala/be/wegenenverkeer/atom/MongoFeedStore.scala
@@ -4,7 +4,7 @@ import be.wegenenverkeer.atom.MongoFeedStore.Keys
 import com.mongodb.casbah.Imports._
 import com.mongodb.casbah.commons.MongoDBObject
 import com.mongodb.{DBObject, casbah}
-import org.joda.time.{DateTime, LocalDateTime}
+import org.joda.time.DateTime
 
 /**
  * [[AbstractFeedStore]] implementation that stores feeds and pages in a MongoDB entriesCollection.
@@ -43,7 +43,7 @@ class MongoFeedStore[E](c: MongoContext,
 
   protected def feedEntry2DbObject(uuid: String, e: E): MongoDBObject = MongoDBObject(
     Keys.Uuid -> uuid,
-    Keys.Timestamp -> new LocalDateTime(),
+    Keys.Timestamp -> new DateTime(),
     Keys.Content -> ser(e)
   )
 
@@ -51,7 +51,7 @@ class MongoFeedStore[E](c: MongoContext,
     val entryDbo = dbo.as[DBObject](Keys.Content)
     FeedEntry(dbo.as[Long](Keys._Id),
           Entry(id = dbo.as[String](Keys.Uuid),
-            updated = dbo.as[DateTime](Keys.Timestamp).toLocalDateTime,
+            updated = dbo.as[DateTime](Keys.Timestamp).toDateTime,
             content = Content(deser(entryDbo), ""), Nil))
   }
 

--- a/modules/server-play/test/be/wegenenverkeer/atom/FeedSupportSuite.scala
+++ b/modules/server-play/test/be/wegenenverkeer/atom/FeedSupportSuite.scala
@@ -1,7 +1,7 @@
 package be.wegenenverkeer.atom
 
 import be.wegenenverkeer.atom.PlayJsonFormats._
-import org.joda.time.{DateTimeUtils, LocalDateTime}
+import org.joda.time.{DateTimeUtils, DateTime}
 import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers, OptionValues}
 import play.api.http.{HeaderNames, MimeTypes}
 import play.api.mvc.Result
@@ -19,7 +19,7 @@ class FeedSupportSuite extends FunSuite with Matchers with OptionValues with Bef
   }
 
   val incompleteFeed: Feed[String] = new Feed("id",
-    Url("http://example.com"), None, None, new LocalDateTime(0), List(Link(Link.selfLink, Url("foo"))), List())
+    Url("http://example.com"), None, None, new DateTime(0), List(Link(Link.selfLink, Url("foo"))), List())
 
   val completeFeed: Feed[String] = incompleteFeed.copy(links = Link(Link.previousLink, Url("prev")) :: incompleteFeed.links)
 
@@ -75,7 +75,7 @@ class FeedSupportSuite extends FunSuite with Matchers with OptionValues with Bef
     }
     val request = FakeRequest().withHeaders(HeaderNames.IF_NONE_MATCH -> incompleteFeed.calcETag)
     val changedFeed = incompleteFeed.copy(entries = Entry[String]("id",
-      new LocalDateTime(),
+      new DateTime(),
       new Content[String]("foo", ""), List()) :: incompleteFeed.entries)
     val result: Future[Result] = feedSupport processFeedPage Some(changedFeed) apply request
     status(result) shouldBe OK
@@ -95,7 +95,7 @@ class FeedSupportSuite extends FunSuite with Matchers with OptionValues with Bef
       registerMarshaller(MimeTypes.JSON, PlayJsonSupport.jsonMarshaller[Feed[String]])
     }
     val request = FakeRequest().withHeaders(HeaderNames.IF_MODIFIED_SINCE -> "Thu, 01 Jan 1970 00:00:00 UTC")
-    val updatedFeed = incompleteFeed.copy(updated = new LocalDateTime(1000)) //1 second later
+    val updatedFeed = incompleteFeed.copy(updated = new DateTime(1000)) //1 second later
     val result: Future[Result] = feedSupport processFeedPage Some(updatedFeed) apply request
     status(result) shouldBe OK
   }

--- a/modules/server-slick/src/main/scala/be/wegenenverkeer/atom/AbstractSlickFeedStore.scala
+++ b/modules/server-slick/src/main/scala/be/wegenenverkeer/atom/AbstractSlickFeedStore.scala
@@ -4,7 +4,7 @@ import _root_.java.util.UUID
 
 import be.wegenenverkeer.atom.models.EntryModel
 import be.wegenenverkeer.atom.slick.FeedComponent
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 /**
  * [[AbstractFeedStore]] implementation that stores feeds and pages in a SQL database.
@@ -54,7 +54,7 @@ import org.joda.time.LocalDateTime
 
   override def push(entries: Iterable[E]): Unit = {
     implicit val session = context.session
-    val timestamp: LocalDateTime = new LocalDateTime()
+    val timestamp: DateTime = new DateTime()
     entries foreach { entry =>
       getEntryTableQuery += EntryModel(None, UUID.randomUUID().toString, ser(entry), timestamp)
     }
@@ -62,7 +62,7 @@ import org.joda.time.LocalDateTime
 
   override def push(uuid: String, entry: E): Unit = {
     implicit val session = context.session
-    val timestamp: LocalDateTime = new LocalDateTime()
+    val timestamp: DateTime = new DateTime()
     getEntryTableQuery += EntryModel(None, uuid, ser(entry), timestamp)
   }
 

--- a/modules/server-slick/src/main/scala/be/wegenenverkeer/atom/models/EntryModel.scala
+++ b/modules/server-slick/src/main/scala/be/wegenenverkeer/atom/models/EntryModel.scala
@@ -1,9 +1,9 @@
 package be.wegenenverkeer.atom.models
 
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 case class EntryModel(
   id: Option[Long],
   uuid: String,
   value: String,
-  timestamp: LocalDateTime)
+  timestamp: DateTime)

--- a/modules/server-slick/src/main/scala/be/wegenenverkeer/atom/slick/FeedComponent.scala
+++ b/modules/server-slick/src/main/scala/be/wegenenverkeer/atom/slick/FeedComponent.scala
@@ -3,7 +3,7 @@ package be.wegenenverkeer.atom.slick
 import java.sql.Date
 
 import be.wegenenverkeer.atom.models.{EntryModel, FeedModel}
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 trait FeedComponent extends DriverComponent {
   this: DriverComponent =>
@@ -14,9 +14,9 @@ trait FeedComponent extends DriverComponent {
     TableQuery[EntryTable]((tag:Tag) => new EntryTable(tag, entriesTableName))
   }
 
-  implicit val jodaLocalDateTimeColumnType = MappedColumnType.base[LocalDateTime, Date](
-  { ldt => new Date(ldt.toDate.getTime) },    // map LocalDateTime to sql.Date
-  { sd => new LocalDateTime(sd.getTime) } // map sql.Date to LocalDateTime
+  implicit val jodaDateTimeColumnType = MappedColumnType.base[DateTime, Date](
+  { ldt => new Date(ldt.toDate.getTime) },    // map DateTime to sql.Date
+  { sd => new DateTime(sd.getTime) } // map sql.Date to DateTime
   )
 
   class EntryTable(tag: Tag, tableName: String) extends Table[EntryModel](tag, tableName) {
@@ -24,7 +24,7 @@ trait FeedComponent extends DriverComponent {
     def id = column[Long]("id", O.AutoInc, O.PrimaryKey)
     def uuid = column[String]("uuid")
     def value = column[String]("value")
-    def timestamp = column[LocalDateTime]("timestamp", O.NotNull)
+    def timestamp = column[DateTime]("timestamp", O.NotNull)
 
     def * = (id.?, uuid, value, timestamp) <> (EntryModel.tupled, EntryModel.unapply)
 

--- a/modules/server/src/main/scala/be/wegenenverkeer/atom/MemoryFeedStore.scala
+++ b/modules/server/src/main/scala/be/wegenenverkeer/atom/MemoryFeedStore.scala
@@ -1,6 +1,6 @@
 package be.wegenenverkeer.atom
 
-import org.joda.time.LocalDateTime
+import org.joda.time.DateTime
 
 import scala.collection.mutable.ListBuffer
 
@@ -32,17 +32,17 @@ class MemoryFeedStore[T](feedName: String,
   override def maxId = entries.size + 1
 
   override def push(it: Iterable[T]) = {
-    val timestamp: LocalDateTime = new LocalDateTime()
+    val timestamp: DateTime = new DateTime()
     it foreach { entry =>
-      push(generateEntryID(), entry, new LocalDateTime())
+      push(generateEntryID(), entry, new DateTime())
     }
   }
 
   override def push(uuid: String, entry: T): Unit = {
-    push(uuid, entry, new LocalDateTime())
+    push(uuid, entry, new DateTime())
   }
 
-  private def push(uuid: String, entry: T, timestamp: LocalDateTime): Unit = {
+  private def push(uuid: String, entry: T, timestamp: DateTime): Unit = {
     entries append Entry(uuid, timestamp, Content(entry, ""), Nil)
   }
 

--- a/modules/server/src/test/scala/be/wegenenverkeer/atom/TestFeedStore.scala
+++ b/modules/server/src/test/scala/be/wegenenverkeer/atom/TestFeedStore.scala
@@ -1,8 +1,8 @@
 package be.wegenenverkeer.atom
 
-import org.joda.time.LocalDateTime
-
 import scala.collection.immutable.TreeMap
+
+import org.joda.time.DateTime
 
 object TestFeedStore {
 
@@ -30,7 +30,7 @@ class TestFeedStore[T] extends AbstractFeedStore[T](
   override def push(entries: Iterable[T]): Unit = {
     entries foreach { e =>
       nextSequenceNum += (skip + 1)
-      entriesMap += (nextSequenceNum -> Entry("id", new LocalDateTime(), Content(e, ""), Nil))
+      entriesMap += (nextSequenceNum -> Entry("id", new DateTime(), Content(e, ""), Nil))
     }
     sequenceNumbersToSkipForPush(0)
   }


### PR DESCRIPTION
LocalDateTime objects changed to DateTime so that a timezone is added when serialising/deserialising to json in accordance with atompub spec