### PR TITLE
play25 support added

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ site.includeScaladoc()
 
 organization in ThisBuild := "be.wegenenverkeer"
 
-scalaVersion in ThisBuild := "2.11.5"
+scalaVersion in ThisBuild := "2.11.8"
 
-crossScalaVersions := Seq("2.10.4", "2.11.5")
+crossScalaVersions := Seq("2.10.4", "2.11.8")
 
 scalacOptions in ThisBuild := Seq(
   "-deprecation",

--- a/modules/common-play25/src/main/scala/be/wegenenverkeer/atomium/play/JacksonSupport.scala
+++ b/modules/common-play25/src/main/scala/be/wegenenverkeer/atomium/play/JacksonSupport.scala
@@ -1,0 +1,30 @@
+package be.wegenenverkeer.atomium.play
+
+import com.fasterxml.jackson.databind.{ObjectReader, ObjectWriter}
+import play.api.mvc.Codec
+
+object JacksonSupport {
+
+  type JsonMarshaller[T] = T => Array[Byte]
+  type JsonUnmarshaller[T] = String => T
+
+  def toJsonBytes(obj: AnyRef)(implicit codec: Codec, writer: ObjectWriter): Array[Byte] =
+    writer.writeValueAsString(obj).getBytes(codec.charset)
+
+  def jacksonMarshaller[T <:AnyRef](implicit codec: Codec, writer: ObjectWriter): JsonMarshaller[T] = {
+    t:T => toJsonBytes(t)
+  }
+
+  def fromJsonBytes[T <:AnyRef](bytes: Array[Byte], charset: String)(implicit reader: ObjectReader): T = {
+    reader.readValue(new String(bytes, charset))
+  }
+
+  def fromJsonString[T](json: String)(implicit reader: ObjectReader): T = {
+    reader.readValue(json)
+  }
+
+  def jacksonUnmarshaller[T <:AnyRef](implicit reader: ObjectReader): JsonUnmarshaller[T] = {
+    json: String => fromJsonString(json).asInstanceOf[T]
+  }
+
+}

--- a/modules/common-play25/src/main/scala/be/wegenenverkeer/atomium/play/JaxbSupport.scala
+++ b/modules/common-play25/src/main/scala/be/wegenenverkeer/atomium/play/JaxbSupport.scala
@@ -1,0 +1,45 @@
+package be.wegenenverkeer.atomium.play
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStreamReader, StringReader}
+import javax.xml.bind._
+
+import play.api.mvc.Codec
+
+object JaxbSupport {
+
+  type XmlMarshaller[T] = T => Array[Byte]
+  type XmlUnmarshaller[T] = String => T
+
+  def toXmlBytes(obj: AnyRef)(implicit codec: Codec, context: JAXBContext): Array[Byte] = {
+    val marshaller = context.createMarshaller()
+    val stream = new ByteArrayOutputStream
+
+    marshaller.setProperty(Marshaller.JAXB_ENCODING, codec.charset)
+    marshaller.marshal(obj, stream)
+
+    stream.toByteArray
+  }
+
+  def jaxbMarshaller[T <:AnyRef](implicit jaxbContext: JAXBContext): XmlMarshaller[T] = {
+    t:T => toXmlBytes(t)
+  }
+
+  def fromXmlString[A](xml: String, expectedType: Class[A])(implicit context: JAXBContext): A = {
+    val result = context.createUnmarshaller().unmarshal(new StringReader(xml))
+    result.asInstanceOf[A]
+  }
+
+  def fromXmlBytes[A](bytes: Array[Byte], charset: String, expectedType: Class[A])(implicit context: JAXBContext): A = {
+    val stream = new ByteArrayInputStream(bytes)
+    val reader = new InputStreamReader(stream, charset)
+    val result = context.createUnmarshaller().unmarshal(reader)
+    expectedType.cast(result)
+  }
+
+  def jaxbUnmarshaller[T](implicit jaxbContext: JAXBContext, manifest: Manifest[T]): XmlUnmarshaller[T] = {
+        //TODO check manifest !!!
+    xml => fromXmlString(xml, manifest.runtimeClass).asInstanceOf[T]
+  }
+
+}
+

--- a/modules/common-play25/src/main/scala/be/wegenenverkeer/atomium/play/PlayJsonFormats.scala
+++ b/modules/common-play25/src/main/scala/be/wegenenverkeer/atomium/play/PlayJsonFormats.scala
@@ -1,0 +1,128 @@
+package be.wegenenverkeer.atomium.play
+
+import be.wegenenverkeer.atomium.format._
+import be.wegenenverkeer.atomium.format.pub._
+import org.joda.time.DateTime
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+
+/**
+ * This object provides the Play JSON formats that can be used by read/write the Atom AST from/to JSON.
+ *
+ * If you want to use this implementation you will need to add a dependency on the Play Json API library.
+ */
+object PlayJsonFormats {
+
+  val datePattern = "yyyy-MM-dd'T'HH:mm:ssZ"
+
+  implicit val jodaDateTimeFormat =
+    Format[DateTime](Reads.jodaDateReads(datePattern), Writes.jodaDateWrites(datePattern))
+
+  implicit val urlFormat = new Format[Url] {
+    override def writes(url: Url): JsValue = JsString(url.path)
+
+    override def reads(json: JsValue): JsResult[Url] = json match {
+      case JsString(value) => JsSuccess(Url(value))
+      case _               => JsError(s"Can't read url value from $json")
+    }
+  }
+
+  implicit val linkFormat = Json.format[Link]
+  implicit val generatorFormat = Json.format[Generator]
+  implicit val draftFormat = new Format[Draft] {
+    override def reads(json: JsValue): JsResult[Draft] = json match {
+      case JsString(value) if value == DraftYes.value => JsSuccess(DraftYes)
+      case JsString(value) if value == DraftNo.value  => JsSuccess(DraftNo)
+      case _                                          => JsError(s"Can't read Draft from $json")
+    }
+
+    override def writes(o: Draft): JsValue = JsString(o.value)
+  }
+  implicit val controlFormat = Json.format[Control]
+
+  implicit def contentWrites[T: Writes]: Writes[Content[T]] = (
+    (__ \ "value").write[T] and
+      (__ \ "type").write[String]
+    )(in => (in.value, in.`type`))
+
+  implicit def contentReads[T: Reads]: Reads[Content[T]] = (
+    (__ \ "value").read[T] and
+      (__ \ "type").read[String]
+    )((value, `type`) => Content[T](value, `type`))
+
+  implicit def entryWrites[T: Writes]: Writes[Entry[T]] = new Writes[Entry[T]] {
+
+    override def writes(o: Entry[T]): JsValue = {
+      o match {
+        case e: AtomPubEntry[T] => atomPubEntryWrites[T].writes(e)
+        case e: AtomEntry[T]    => atomEntryWrites[T].writes(e)
+      }
+    }
+  }
+
+  implicit def atomEntryWrites[T: Writes]: Writes[AtomEntry[T]] = (
+    (__ \ "id").write[String] and
+      (__ \ "updated").write[DateTime] and
+      (__ \ "content").write[Content[T]] and
+      (__ \ "links").write[List[Link]] and
+      (__ \ "_type").write[String] // type information
+    )(in => (in.id, in.updated, in.content, in.links, "atom"))
+
+  implicit def atomPubEntryWrites[T: Writes]: Writes[AtomPubEntry[T]] = (
+    (__ \ "id").write[String] and
+      (__ \ "updated").write[DateTime] and
+      (__ \ "content").write[Content[T]] and
+      (__ \ "links").write[List[Link]] and
+      (__ \ "edited").write[DateTime] and
+      (__ \ "control").write[Control] and
+      (__ \ "_type").write[String] // type information
+    )(in => (in.id, in.updated, in.content, in.links, in.edited, in.control, "atom-pub"))
+
+  implicit def entryReads[T: Reads]: Reads[Entry[T]] = new Reads[Entry[T]] {
+    override def reads(json: JsValue): JsResult[Entry[T]] = {
+      val hasControl = (json \ "_type").asOpt[String]
+      hasControl match {
+        case Some("atom-pub") => atomPubEntryReads[T].reads(json)
+        case _                => atomEntryReads[T].reads(json)
+      }
+    }
+  }
+
+  implicit def atomEntryReads[T: Reads]: Reads[AtomEntry[T]] = (
+    (__ \ "id").read[String] and
+      (__ \ "updated").read[DateTime] and
+      (__ \ "content").read[Content[T]] and
+      (__ \ "links").read[List[Link]]
+    )((id, updated, content, links) => AtomEntry[T](id, updated, content, links))
+
+  implicit def atomPubEntryReads[T: Reads]: Reads[AtomPubEntry[T]] = (
+    (__ \ "id").read[String] and
+      (__ \ "updated").read[DateTime] and
+      (__ \ "content").read[Content[T]] and
+      (__ \ "links").read[List[Link]] and
+      (__ \ "edited").read[DateTime] and
+      (__ \ "control").read[Control]
+    )((id, updated, content, links, edited, control) => AtomPubEntry[T](id, updated, content, links, edited, control))
+
+  // candidate for macro format
+  implicit def feedWrites[T: Writes]: Writes[Feed[T]] = (
+    (__ \ "id").write[String] and
+      (__ \ "base").write[Url] and
+      (__ \ "title").writeNullable[String] and
+      (__ \ "generator").writeNullable[Generator] and
+      (__ \ "updated").write[DateTime] and
+      (__ \ "links").write[List[Link]] and
+      (__ \ "entries").write[List[Entry[T]]]
+    )(in => (in.id, in.base, in.title, in.generator, in.updated, in.links, in.entries))
+
+  implicit def feedReads[T: Reads]: Reads[Feed[T]] = (
+    (__ \ "id").read[String] and
+      (__ \ "base").read[Url] and
+      (__ \ "title").readNullable[String] and
+      (__ \ "generator").readNullable[Generator] and
+      (__ \ "updated").read[DateTime] and
+      (__ \ "links").read[List[Link]] and
+      (__ \ "entries").read[List[Entry[T]]]
+    )((id, base, title, generator, updated, links, entries) => Feed[T](id, base, title, generator, updated, links, entries))
+
+}

--- a/modules/common-play25/src/main/scala/be/wegenenverkeer/atomium/play/PlayJsonSupport.scala
+++ b/modules/common-play25/src/main/scala/be/wegenenverkeer/atomium/play/PlayJsonSupport.scala
@@ -1,0 +1,17 @@
+package be.wegenenverkeer.atomium.play
+
+import play.api.libs.json.{Json, Reads, Writes}
+
+object PlayJsonSupport {
+
+  type JsonMarshaller[T] = T => Array[Byte]
+  type JsonUnmarshaller[T] = String => T
+
+  def jsonUnmarshaller[T <:AnyRef](implicit reads: Reads[T]): JsonUnmarshaller[T] = {
+    json => Json.parse(json).as[T]
+  }
+
+  def jsonMarshaller[T](implicit writes: Writes[T]): JsonMarshaller[T] = {
+    t => Json.toJson(t).toString().getBytes("utf-8")
+  }
+}

--- a/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/FeedMarshaller.scala
+++ b/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/FeedMarshaller.scala
@@ -1,0 +1,17 @@
+package be.wegenenverkeer.atomium.server.play
+
+import be.wegenenverkeer.atomium.format.Feed
+
+trait FeedMarshaller[T] {
+
+  /** The content type */
+  type ContentType = String
+
+  /**
+   * Serializes a `Feed` to `Array[Byte]` format
+   *
+   * @return a tuple of `ContentType` (ie: String) indicating the serialized format and an `Array[Byte]` containing the serialized `Feed`.
+   */
+  def marshall(feed: Feed[T]): (ContentType, Array[Byte])
+
+}

--- a/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/FeedSupport.scala
+++ b/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/FeedSupport.scala
@@ -1,0 +1,147 @@
+package be.wegenenverkeer.atomium.server.play
+
+import java.util.Locale
+
+import be.wegenenverkeer.atomium.format.{Feed, Generator, Url}
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.{DateTime, Duration}
+import org.slf4j.LoggerFactory
+import play.api.http.{HeaderNames, MediaRange}
+import play.api.mvc._
+
+import scala.concurrent.Future
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+
+/**
+ * trait supporting serving of feed pages:
+ * sets correct caching headers
+ * sets ETag and Last-Modified response headers and responds with Not-Modified if needed to reduce bandwidth
+ * supports content-negotiation and responds with either JSON or XML depending on registered marshallers
+ *
+ * @tparam T the type of the feed entries²
+ */
+trait FeedSupport[T] extends Results with HeaderNames with Rendering with AcceptExtractors {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  private val cacheTime = 60 * 60 * 24 * 365 //365 days, 1 year (approximately)
+
+  private val generator = Generator("atomium", Some(Url("http://github.com/WegenenVerkeer/atomium")), Some("0.0.1"))
+
+  val rfcFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss z").withLocale(Locale.ENGLISH)
+  val rfcUTCFormat = rfcFormat.withZoneUTC()
+
+  /**
+   * Define the PartialFunction that will map acceptable content types to FeedMarshallers.
+   *
+   *
+   * For instance:
+   * {{{
+   *   // supports XML and JSON and used predefined FeedMarshallers
+   *   override def marshallers = {
+   *     case Accepts.Xml()  => JaxbFeedMarshaller[String]()
+   *     case Accepts.Json() => PlayJsonFeedMarshaller[String]()
+   *   }
+   * }}}
+   *
+   * or in case a specifc content types is need...
+   *
+   * {{{
+   *   // supports XML and JSON and used predefined FeedMarshallers
+   *   override def marshallers = {
+   *     case Accepts.Xml()  => JaxbFeedMarshaller[String]("application/my-api-v1.0+xml")
+   *     case Accepts.Json() => PlayJsonFeedMarshaller[String]("application/my-api-v1.0+json")
+   *   }
+   * }}}
+   *
+   *
+   * @return `PartialFunction[MediaRange, FeedMarshaller]`
+   */
+  def marshallers: PartialFunction[MediaRange, FeedMarshaller[T]]
+
+  private def buildRenders(feed: Feed[T]): PartialFunction[MediaRange, Result] = {
+    new PartialFunction[MediaRange, Result] {
+      override def isDefinedAt(x: MediaRange): Boolean = marshallers.isDefinedAt(x)
+
+      override def apply(v1: MediaRange): Result = {
+        val feedMarshaller = marshallers.apply(v1)
+        marshall(feedMarshaller, feed)
+      }
+    }
+  }
+
+  /**
+   * marshall the feed and set correct headers
+   * @param page the optional page of the feed
+   * @param codec the implicit codec
+   * @return the response
+   */
+  def processFeedPage(page: Future[Option[Feed[T]]])(implicit codec: Codec) = Action.async { implicit request =>
+    logger.info(s"processing request: $request")
+    page.map {
+      case Some(f) =>
+        if (notModified(f, request.headers)) {
+          logger.info("sending response: 304 Not-Modified")
+          NotModified
+        } else {
+          //add generator
+          val feed = f.copy(generator = Some(generator))
+          render(buildRenders(feed))
+        }
+      case None    =>
+        logger.info("sending response: 404 Not-Found")
+        NotFound("feed or page not found")
+    }
+  }
+
+  def processFeedPage(page: Option[Feed[T]])(implicit codec: Codec): Action[AnyContent] = {
+    processFeedPage(Future.successful(page))
+  }
+
+  private def marshall(feedMarshaller: FeedMarshaller[T], feed: Feed[T]): Result = {
+    //marshall feed and add Last-Modified header
+
+    val (contentType, payload) = feedMarshaller.marshall(feed)
+
+    logger.info("sending response: 200 Found")
+    val result = Ok(payload)
+      .withHeaders(LAST_MODIFIED -> rfcUTCFormat.print(feed.updated.toDateTime), ETAG -> feed.calcETag)
+
+    //add extra cache headers or forbid caching
+    val resultWithCacheHeader =
+      if (feed.complete()) {
+        val expires = new DateTime().withDurationAdded(new Duration(cacheTime * 1000L), 1)
+        result.withHeaders(CACHE_CONTROL -> {
+          "public, max-age=" + cacheTime
+        }, EXPIRES -> rfcUTCFormat.print(expires))
+      } else {
+        result.withHeaders(CACHE_CONTROL -> "public, max-age=0, no-cache, must-revalidate")
+      }
+
+    resultWithCacheHeader.as(contentType)
+  }
+
+  //if modified since 02-11-2014 12:00:00 and updated on 02-11-2014 15:00:00 => modified => false
+  //if modified since 02-11-2014 12:00:00 and updated on 02-11-2014 10:00:00 => not modified => true
+  //if modified since 02-11-2014 12:00:00 and updated on 02-11-2014 12:00:00 => not modified => true
+  private def notModified(f: Feed[T], headers: Headers): Boolean = {
+
+    val ifNoneMatch = headers get IF_NONE_MATCH exists {
+      _ == f.calcETag
+    }
+
+    val ifModifiedSince = headers get IF_MODIFIED_SINCE exists { dateStr =>
+      try {
+        rfcFormat.parseDateTime(dateStr).toDate.getTime >= f.updated.withMillisOfSecond(0).toDate.getTime
+      }
+      catch {
+        case e: IllegalArgumentException =>
+          logger.error(e.getMessage, e)
+          false
+      }
+    }
+
+    ifNoneMatch || ifModifiedSince
+  }
+
+}

--- a/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/JacksonFeedMarshaller.scala
+++ b/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/JacksonFeedMarshaller.scala
@@ -1,0 +1,28 @@
+package be.wegenenverkeer.atomium.server.play
+
+import be.wegenenverkeer.atomium.format.Feed
+import be.wegenenverkeer.atomium.format.FeedConverters._
+import be.wegenenverkeer.atomium.play.JacksonSupport
+import com.fasterxml.jackson.databind.ObjectWriter
+import play.api.http.MimeTypes
+import play.api.mvc.Codec
+
+
+/**
+ * A Feed marshaller backed by a `Jackson` marshaller
+ *
+ * @param contentType - the desired content type of the serialized `Feed`
+ * @param codec - a implicitly provided [[Codec]]
+ * @param writer - a implicitly provided [[ObjectWriter]]
+ * @tparam T - the type of the `Feed` content
+ */
+case class JacksonFeedMarshaller[T](contentType: String = MimeTypes.JSON)(implicit codec: Codec, writer: ObjectWriter)
+  extends FeedMarshaller[T] {
+
+  /** Serializes a `Feed` to JSON format */
+  override def marshall(feed: Feed[T]): (ContentType, Array[Byte]) = {
+    val toJavaEventFeed = (feed: Feed[T]) => feed.asJava
+    val xmlMarshaller = toJavaEventFeed andThen JacksonSupport.jacksonMarshaller
+    (contentType, xmlMarshaller(feed))
+  }
+}

--- a/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/JaxbFeedMarshaller.scala
+++ b/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/JaxbFeedMarshaller.scala
@@ -1,0 +1,25 @@
+package be.wegenenverkeer.atomium.server.play
+
+import javax.xml.bind.JAXBContext
+
+import be.wegenenverkeer.atomium.format.Feed
+import be.wegenenverkeer.atomium.format.FeedConverters._
+import be.wegenenverkeer.atomium.play.JaxbSupport
+import play.api.http.MimeTypes
+
+/**
+ * A Feed marshaller backed by a `Jaxb` marshaller
+ *
+ * @param contentType - the desired content type of the serialized `Feed`
+ * @param jaxbContext - a implicitly provided [[JAXBContext]]
+ * @tparam T - the type of the `Feed` content
+ */
+case class JaxbFeedMarshaller[T](contentType: String = MimeTypes.XML)(implicit jaxbContext: JAXBContext) extends FeedMarshaller[T] {
+
+  /** Serializes a `Feed` to XML format */
+  override def marshall(feed: Feed[T]): (ContentType, Array[Byte]) = {
+    val toJavaFeed = (feed: Feed[T]) => feed.asJava
+    val xmlMarshaller = toJavaFeed andThen JaxbSupport.jaxbMarshaller
+    (contentType, xmlMarshaller(feed))
+  }
+}

--- a/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/PlayJsonFeedMarshaller.scala
+++ b/modules/server-play25/src/main/scala/be/wegenenverkeer/atomium/server/play/PlayJsonFeedMarshaller.scala
@@ -1,0 +1,22 @@
+package be.wegenenverkeer.atomium.server.play
+
+import be.wegenenverkeer.atomium.format.Feed
+import be.wegenenverkeer.atomium.play.PlayJsonSupport
+import play.api.http.MimeTypes
+import play.api.libs.json.Writes
+import be.wegenenverkeer.atomium.play.PlayJsonFormats.feedWrites
+
+/**
+ * A Feed marshaller backed by a `play json` marshaller
+ *
+ * @param contentType - the desired content type of the serialized `Feed`
+ * @param writes - a implicitly provided play-json [[Writes]] for `T`
+ * @tparam T - the type of the `Feed` content
+ */
+case class PlayJsonFeedMarshaller[T](contentType: String = MimeTypes.JSON)(implicit writes: Writes[T]) extends FeedMarshaller[T] {
+
+  /** Serializes a `Feed` to JSON format. */
+  override def marshall(feed: Feed[T]): (ContentType, Array[Byte]) = {
+    (contentType, PlayJsonSupport.jsonMarshaller(feedWrites(writes))(feed))
+  }
+}

--- a/project/AtomiumBuild.scala
+++ b/project/AtomiumBuild.scala
@@ -1,6 +1,5 @@
-import play.Play.autoImport._
-import play.PlayScala
-import Dependencies._
+import play.sbt.Play.autoImport._
+import play.sbt.PlayScala
 import sbt.Keys._
 import sbt._
 
@@ -31,6 +30,7 @@ object AtomiumBuild extends Build with BuildSettings {
   lazy val formatModule =
     project("format")
       .settings(libraryDependencies ++= mainScalaTestDependencies)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(javaFormatModule)
 
 
@@ -43,6 +43,7 @@ object AtomiumBuild extends Build with BuildSettings {
     project("client-akka")
       .settings(publishArtifact in Test := true)
       .settings(libraryDependencies ++= mainDeps ++ testDeps)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(formatModule, serverModule, clientJavaModule % "test->test;compile->compile", clientScalaModule % "test->test;compile->compile")
       .aggregate(formatModule, serverModule)
   }
@@ -56,6 +57,7 @@ object AtomiumBuild extends Build with BuildSettings {
     project("client-scala")
       .settings(publishArtifact in Test := true)
       .settings(libraryDependencies ++= mainDeps ++ testDeps)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(formatModule, serverModule, clientJavaModule % "test->test;compile->compile")
       .aggregate(formatModule, serverModule)
   }
@@ -82,6 +84,7 @@ object AtomiumBuild extends Build with BuildSettings {
 
     project("common-play")
       .settings(libraryDependencies ++= mainDeps ++ mainScalaTestDependencies)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(formatModule)
       .aggregate(formatModule)
   }
@@ -93,6 +96,7 @@ object AtomiumBuild extends Build with BuildSettings {
 
     project("common-play25")
       .settings(libraryDependencies ++= mainDeps ++ mainScalaTestDependencies)
+      .settings(crossScalaVersions := Seq("2.11.8"))
       .dependsOn(formatModule)
       .aggregate(formatModule)
   }
@@ -101,6 +105,7 @@ object AtomiumBuild extends Build with BuildSettings {
   lazy val serverModule =
     project("server")
       .settings(libraryDependencies ++= mainScalaTestDependencies)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(formatModule)
 
 
@@ -112,6 +117,7 @@ object AtomiumBuild extends Build with BuildSettings {
 
     project("server-mongo")
       .settings(libraryDependencies ++= mainDeps ++ testDeps)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(serverModule % "test->test;compile->compile")
   }
 
@@ -124,6 +130,7 @@ object AtomiumBuild extends Build with BuildSettings {
 
     project("server-slick")
       .settings(libraryDependencies ++= mainDeps ++ testDeps)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(serverModule % "test->test;compile->compile")
   }
 
@@ -135,6 +142,7 @@ object AtomiumBuild extends Build with BuildSettings {
 
     project("server-jdbc")
       .settings(libraryDependencies ++= testDeps)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(serverModule % "test->test;compile->compile")
   }
 
@@ -147,6 +155,7 @@ object AtomiumBuild extends Build with BuildSettings {
 
     project("server-play")
       .settings(libraryDependencies ++= mainDeps ++ testDeps)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(serverModule % "test->test;compile->compile", commonPlayModule)
   }
 
@@ -158,6 +167,7 @@ object AtomiumBuild extends Build with BuildSettings {
 
     project("server-play25")
       .settings(libraryDependencies ++= mainDeps ++ testDeps)
+      .settings(crossScalaVersions := Seq("2.11.8"))
       .dependsOn(serverModule % "test->test;compile->compile", commonPlay25Module)
   }
 
@@ -166,6 +176,7 @@ object AtomiumBuild extends Build with BuildSettings {
    
     project("server-play-sample")
       .enablePlugins(PlayScala)
+      .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(serverModule % "test->test;compile->compile", serverPlayModule)
   }
 

--- a/project/AtomiumBuild.scala
+++ b/project/AtomiumBuild.scala
@@ -86,6 +86,16 @@ object AtomiumBuild extends Build with BuildSettings {
       .aggregate(formatModule)
   }
 
+  //----------------------------------------------------------------
+  lazy val commonPlay25Module = {
+
+    val mainDeps = Seq(play25, play25Json)
+
+    project("common-play25")
+      .settings(libraryDependencies ++= mainDeps ++ mainScalaTestDependencies)
+      .dependsOn(formatModule)
+      .aggregate(formatModule)
+  }
 
   //----------------------------------------------------------------
   lazy val serverModule =
@@ -140,7 +150,18 @@ object AtomiumBuild extends Build with BuildSettings {
       .dependsOn(serverModule % "test->test;compile->compile", commonPlayModule)
   }
 
- //----------------------------------------------------------------
+  //----------------------------------------------------------------
+  lazy val serverPlay25Module = {
+
+    val mainDeps = Seq()
+    val testDeps = Seq(playMockWs, play25Test, scalaTestPlay) ++ mainScalaTestDependencies
+
+    project("server-play25")
+      .settings(libraryDependencies ++= mainDeps ++ testDeps)
+      .dependsOn(serverModule % "test->test;compile->compile", commonPlay25Module)
+  }
+
+  //----------------------------------------------------------------
   lazy val serverPlaySampleModule = {
    
     project("server-play-sample")
@@ -154,6 +175,7 @@ object AtomiumBuild extends Build with BuildSettings {
     javaFormatModule,
     formatModule,
     commonPlayModule,
+    commonPlay25Module,
     clientAkkaModule,
     clientScalaModule,
     clientJavaModule,
@@ -162,6 +184,7 @@ object AtomiumBuild extends Build with BuildSettings {
     serverSlickModule,
     serverJdbcModule,
     serverPlayModule,
+    serverPlay25Module,
     serverPlaySampleModule
   )
 }

--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -1,8 +1,7 @@
 import de.johoop.jacoco4sbt.JacocoPlugin._
 import sbt.Keys._
 import sbt.{Configuration, _}
-
-import scala.util.Properties
+import sbtdoge.CrossPerProjectPlugin
 
 trait BuildSettings {
 
@@ -26,6 +25,7 @@ trait BuildSettings {
       settings = projectSettings()
     ).settings(publishArtifact := false)
       .aggregate(modules: _*)
+      .enablePlugins(CrossPerProjectPlugin)
   }
 
   private def projectSettings() = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,6 +4,7 @@ import sbt._
 object Dependencies {
 
   val playVersion = "2.4.2"
+  val play25Version = "2.5.4"
 
   // main deps
   val logback           = "ch.qos.logback"              %     "logback-classic"               % "1.1.1"
@@ -18,6 +19,12 @@ object Dependencies {
   val slick             = "com.typesafe.slick"          %%    "slick"                         % "2.1.0"
   val slickPostgres     = "com.github.tminglei"         %%    "slick-pg"                      % "0.7.0"
   val akkaPersistence   = "com.typesafe.akka"           %%    "akka-persistence-experimental" % "2.3.12"
+
+  //play25 deps
+  val play25Json          = "com.typesafe.play"           %%    "play-json"                     % play25Version
+  val play25Ws            = "com.typesafe.play"           %%    "play-ws"                       % play25Version
+  val play25              = "com.typesafe.play"           %%    "play"                          % play25Version
+  val play25Test          = "com.typesafe.play"           %%    "play-test"                     % play25Version    % "test"
 
   // test deps
   val scalaTest         = "org.scalatest"               %%    "scalatest"               % "2.2.0"        % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.11

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,3 +20,5 @@ addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.4.2")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "0.5.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
+addSbtPlugin("com.eed3si9n" % "sbt-doge" % "0.1.5")

--- a/version.sbt
+++ b/version.sbt
@@ -1,5 +1,5 @@
 val snapshotSuffix = "-SNAPSHOT"
 
-version in ThisBuild := "0.8.2" //+ snapshotSuffix
+version in ThisBuild := "0.8.3" + snapshotSuffix
 
 isSnapshot := version.value.endsWith(snapshotSuffix)


### PR DESCRIPTION
This PR adds play2.5 support
Instead of maintaining a different branch where we upgrade the play depedencies to 2.5, I opted to have extra separate atomium-common-play25 and atomium-server-play25 modules.
It is copy-paste, but I don't see another solution if you want to keep play2.4 support in the foreseeable future.