### PR TITLE
accept header configurable

### DIFF
--- a/modules/client-java/src/main/java/be/wegenenverkeer/atomium/japi/client/AtomiumClient.java
+++ b/modules/client-java/src/main/java/be/wegenenverkeer/atomium/japi/client/AtomiumClient.java
@@ -469,6 +469,16 @@ public class AtomiumClient {
         }
 
         /**
+         * Sets the Accept-header to user supplied string.
+         *
+         * @return this {@link be.wegenenverkeer.rxhttp.RxHttpClient.Builder}
+         */
+        public Builder setAccept(String accept) {
+            rxHttpClientBuilder.setAccept(accept);
+            return this;
+        }
+
+        /**
          * Sets the Accept-header to JSON.
          *
          * @return this {@link be.wegenenverkeer.rxhttp.RxHttpClient.Builder}


### PR DESCRIPTION
Make the accept header for atomium client configurable (instead of hardcoded to application/json or ../xml)