### PR TITLE
_type field optional

### DIFF
--- a/modules/format-java/src/main/java/be/wegenenverkeer/atomium/japi/format/Entry.java
+++ b/modules/format-java/src/main/java/be/wegenenverkeer/atomium/japi/format/Entry.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.List;
 
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type", defaultImpl = AtomEntry.class)
 @JsonSubTypes({
         @JsonSubTypes.Type(value = AtomPubEntry.class, name = "atom-pub"),
         @JsonSubTypes.Type(value = AtomEntry.class, name = "atom")})


### PR DESCRIPTION
Makes the "_type" field in the pub entries optional for feeds which don't have this non-atom-pub-specification field