### PR TITLE
An empty feed is a valid feed without entries

### DIFF
--- a/modules/client-scala/src/test/scala/be/wegenenverkeer/atomium/client/FeedProviderFixture.scala
+++ b/modules/client-scala/src/test/scala/be/wegenenverkeer/atomium/client/FeedProviderFixture.scala
@@ -47,8 +47,7 @@ trait FeedProviderFixture[E] {
     private def fetchLastFeed: Option[Feed[E]] = {
       val lastFeed =
         for {
-          feed <- feedService.getHeadOfFeed()
-          lastUrl <- feed.lastLink
+          lastUrl <- feedService.getHeadOfFeed().lastLink
           lastFeed <- getFeedPage(lastUrl.href)
         } yield lastFeed
       lastFeed

--- a/modules/server-play-sample/app/controllers/EventController.scala
+++ b/modules/server-play-sample/app/controllers/EventController.scala
@@ -36,7 +36,7 @@ class EventController() extends Controller with FeedSupport[Event] {
    * @return the head of the page
    */
   def headOfFeed() = {
-    processFeedPage(feedService.getHeadOfFeed())
+    processFeedPage(Some(feedService.getHeadOfFeed()))
   }
 
   /**

--- a/modules/server-play-sample/app/controllers/StringController.scala
+++ b/modules/server-play-sample/app/controllers/StringController.scala
@@ -36,7 +36,7 @@ class StringController() extends Controller with FeedSupport[String] {
    * @return the head of the feed
    */
   def headOfFeed() = {
-    processFeedPage(Future.successful(feedService.getHeadOfFeed()))
+    processFeedPage(Future.successful(Some(feedService.getHeadOfFeed())))
   }
 
   /**

--- a/modules/server/src/main/scala/be/wegenenverkeer/atomium/japi/server/FeedService.scala
+++ b/modules/server/src/main/scala/be/wegenenverkeer/atomium/japi/server/FeedService.scala
@@ -27,7 +27,7 @@ class FeedService[E, C <: Context](entriesPerPage: Integer, feedStore: FeedStore
     override def getFeed(startSequenceNr: Long, count: Int, forward: Boolean)(implicit context: C): Option[format.Feed[E]] =
       feedStore.getFeed(startSequenceNr, count, forward, context)
 
-    override def getHeadOfFeed(pageSize: Int)(implicit context: C): Option[format.Feed[E]] =
+    override def getHeadOfFeed(pageSize: Int)(implicit context: C): format.Feed[E] =
       feedStore.getHeadOfFeed(pageSize, context)
 
     override def push(entries: Iterable[E])(implicit context: C): Unit =

--- a/modules/server/src/main/scala/be/wegenenverkeer/atomium/japi/server/FeedStore.scala
+++ b/modules/server/src/main/scala/be/wegenenverkeer/atomium/japi/server/FeedStore.scala
@@ -29,7 +29,7 @@ abstract class FeedStore[E, C <: Context](feedName: String, title: Option[String
    * @param pageSize the maximum number of feed entries to return. The page could contain less entries
    * @return the head of the feed
    */
-  def getHeadOfFeed(pageSize: Int, context: C): Option[format.Feed[E]] =
+  def getHeadOfFeed(pageSize: Int, context: C): format.Feed[E] =
     underlying.getHeadOfFeed(pageSize)(context)
 
   /**

--- a/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/AbstractFeedStore.scala
+++ b/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/AbstractFeedStore.scala
@@ -24,17 +24,17 @@ abstract class AbstractFeedStore[E, C <: Context](feedName: String,
    * @return the feed page or `None` if the page is not found
    */
   override def getFeed(start: Long, pageSize: Int, forward: Boolean)(implicit context: C): Option[Feed[E]] = {
-    require(pageSize > 0)
+    require(pageSize > 0, "page size must be greater than 0")
     val allowed =
       if (forward)
-        start < maxId && getNumberOfEntriesLowerThan(start) % pageSize == 0
+        start == 0 || (start < maxId && getNumberOfEntriesLowerThan(start) % pageSize == 0)
       else
-        start <= maxId && getNumberOfEntriesLowerThan(start, inclusive = false) % pageSize == 0
+        start > 1 && start <= maxId && getNumberOfEntriesLowerThan(start, inclusive = false) % pageSize == 0
 
     if (allowed) {
       // retrieve two entries more then requested and start is inclusive in next call
       // this is done to determine if there is a next and/or previous entry relative to the requested page
-      processFeedEntries(start, minId, pageSize, forward, getFeedEntries(start, pageSize + 2, forward))
+      Some(processFeedEntries(start, minId, pageSize, forward, getFeedEntries(start, pageSize + 2, forward)))
     } else {
       None
     }
@@ -45,7 +45,7 @@ abstract class AbstractFeedStore[E, C <: Context](feedName: String,
    * @param pageSize the maximum number of feed entries to return. The page could contain less entries
    * @return the head of the feed
    */
-  override def getHeadOfFeed(pageSize: Int)(implicit context: C): Option[Feed[E]] = {
+  override def getHeadOfFeed(pageSize: Int)(implicit context: C): Feed[E] = {
 
     require(pageSize > 0, "page size must be greater than 0")
 
@@ -55,7 +55,7 @@ abstract class AbstractFeedStore[E, C <: Context](feedName: String,
     if (entries.nonEmpty) {
       processHeadFeedEntries(getNumberOfEntriesLowerThan(entries.head.sequenceNr), minId, pageSize, entries)
     } else {
-      None
+      processHeadFeedEntries(0, minId, pageSize, entries)
     }
   }
 

--- a/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/AsyncFeedService.scala
+++ b/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/AsyncFeedService.scala
@@ -72,7 +72,7 @@ class AsyncFeedService[E, C <: Context](entriesPerPage: Int, feedStore: AsyncFee
    * @return the head of the feed. This is the first page containing the most recent entries
    */
   def getHeadOfFeed()
-                   (implicit executionContext: ExecutionContext, context: C): Future[Option[Feed[E]]] = {
+                   (implicit executionContext: ExecutionContext, context: C): Future[Feed[E]] = {
     feedStore.getHeadOfFeed(entriesPerPage)
   }
 

--- a/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/AsyncFeedStore.scala
+++ b/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/AsyncFeedStore.scala
@@ -29,7 +29,7 @@ trait AsyncFeedStore[E, C <: Context] {
    * @return the head of the feed
    */
   def getHeadOfFeed(pageSize: Int)
-                   (implicit executionContext: ExecutionContext, context: C): Future[Option[Feed[E]]]
+                   (implicit executionContext: ExecutionContext, context: C): Future[Feed[E]]
 
 
   /**

--- a/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/FeedService.scala
+++ b/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/FeedService.scala
@@ -68,7 +68,7 @@ class FeedService[E, C <: Context](entriesPerPage: Int, feedStore: FeedStore[E, 
    * @param context the context, which is required for feed stores
    * @return the head of the feed. This is the first page containing the most recent entries
    */
-  def getHeadOfFeed()(implicit context: C): Option[Feed[E]] = {
+  def getHeadOfFeed()(implicit context: C): Feed[E] = {
     feedStore.getHeadOfFeed(entriesPerPage)
   }
 

--- a/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/FeedStore.scala
+++ b/modules/server/src/main/scala/be/wegenenverkeer/atomium/server/FeedStore.scala
@@ -25,7 +25,7 @@ trait FeedStore[E, C <: Context] {
    * @param pageSize the maximum number of feed entries to return. The page could contain less entries
    * @return the head of the feed
    */
-  def getHeadOfFeed(pageSize: Int)(implicit context: C): Option[Feed[E]]
+  def getHeadOfFeed(pageSize: Int)(implicit context: C): Feed[E]
 
   /**
    * push a list of entries to the feed

--- a/modules/server/src/test/scala/be/wegenenverkeer/atomium/server/AbstractFeedStorePropertySuite.scala
+++ b/modules/server/src/test/scala/be/wegenenverkeer/atomium/server/AbstractFeedStorePropertySuite.scala
@@ -25,7 +25,7 @@ class AbstractFeedStorePropertySuite extends FunSuite with Matchers with Generat
 
   test("head of non-empty feed is correct") {
     forAll(validFeedStores, validPageSizes) { (feedStore: FeedStore[Int, Context], pageSize: Int) =>
-      val head: Feed[Int] = feedStore.getHeadOfFeed(pageSize).get
+      val head: Feed[Int] = feedStore.getHeadOfFeed(pageSize)
       head.complete shouldBe false
       head.entries.size should be > 0
       head.entries.size should be <= pageSize
@@ -55,7 +55,7 @@ class AbstractFeedStorePropertySuite extends FunSuite with Matchers with Generat
 
   test("navigate from head to tail") {
     forAll(validFeedStores, validPageSizes) { (feedStore: FeedStore[Int, Context], pageSize: Int) =>
-      var page: Feed[Int] = feedStore.getHeadOfFeed(pageSize).get
+      var page: Feed[Int] = feedStore.getHeadOfFeed(pageSize)
       page.entries.size should be > 0
       page.entries.size should be <= pageSize
       while (page.nextLink != None) {

--- a/modules/server/src/test/scala/be/wegenenverkeer/atomium/server/AbstractFeedStoreTest.scala
+++ b/modules/server/src/test/scala/be/wegenenverkeer/atomium/server/AbstractFeedStoreTest.scala
@@ -9,12 +9,12 @@ class AbstractFeedStoreTest extends FunSuite with FeedStoreTestSupport with Matc
 
   test("empty store") {
     val feedStore = new TestFeedStore[Int, Context]()
-    feedStore.getHeadOfFeed(1) shouldBe None
-    feedStore.getHeadOfFeed(3) shouldBe None
+    feedStore.getHeadOfFeed(1).entries.size shouldBe 0
+    feedStore.getHeadOfFeed(3).entries.size shouldBe 0
     intercept[IllegalArgumentException] {
       feedStore.getHeadOfFeed(0)
     }
-    feedStore.getFeed(0, 2, forward = true) shouldBe None
+    feedStore.getFeed(0, 2, forward = true).get.entries.size shouldBe 0
     feedStore.getFeed(10, 2, forward = false) shouldBe None
     intercept[IllegalArgumentException] {
       feedStore.getFeed(10, 0, forward = false)
@@ -107,7 +107,7 @@ class AbstractFeedStoreTest extends FunSuite with FeedStoreTestSupport with Matc
     lastPageOfFeedWithSize5.selfLink should be (Link(Link.selfLink, Url("0/forward/5")))
 
     //since only 1 page in feed => head equals last
-    feedStore.getHeadOfFeed(5).get shouldEqual lastPageOfFeedWithSize5
+    feedStore.getHeadOfFeed(5) shouldEqual lastPageOfFeedWithSize5
 
     feedStore.getFeed(9, 5, forward = true) shouldBe None
 
@@ -139,7 +139,7 @@ class AbstractFeedStoreTest extends FunSuite with FeedStoreTestSupport with Matc
     firstPageOfFeedWithSize2.selfLink should be(Link(Link.selfLink, Url("8/forward/2")))
 
     //we are at the head of the feed
-    feedStore.getHeadOfFeed(2).get shouldEqual firstPageOfFeedWithSize2
+    feedStore.getHeadOfFeed(2) shouldEqual firstPageOfFeedWithSize2
 
     //moving backwards
     feedStore.getFeed(9, 2, forward =  false).get shouldEqual middlePageOfFeedWithSize2

--- a/modules/server/src/test/scala/be/wegenenverkeer/atomium/server/FeedStoreTestSupport.scala
+++ b/modules/server/src/test/scala/be/wegenenverkeer/atomium/server/FeedStoreTestSupport.scala
@@ -40,7 +40,7 @@ trait FeedStoreTestSupport extends Matchers {
     feedPage.entries.map(_.content.value) shouldEqual reverseSortedList(2 * pageSize, pageSize + minId + 1)
 
     //head of feed = first page containing newest entries
-    feedStore.getHeadOfFeed(pageSize).get shouldEqual feedPage
+    feedStore.getHeadOfFeed(pageSize) shouldEqual feedPage
 
     //navigate backwards
     feedStore.getFeed(minId + pageSize + 1, pageSize, forward = false).get shouldEqual lastPage
@@ -58,7 +58,7 @@ trait FeedStoreTestSupport extends Matchers {
     newFirstPage.nextLink.map(_.href) should be(Some(Url(s"${minId + 2 * pageSize + 1}/backward/$pageSize")))
 
     //head of feed = first page containing newest entries
-    feedStore.getHeadOfFeed(pageSize).get shouldEqual newFirstPage
+    feedStore.getHeadOfFeed(pageSize) shouldEqual newFirstPage
 
     //old first page should be complete now
     val middlePage = feedStore.getFeed(minId + pageSize, pageSize, forward = true).get


### PR DESCRIPTION
Requesting the head of an empty feed should not give a 404 feed or page not found
Implies that getHeadOfFeed returns Feed instead of Option[Feed]