### PR TITLE
atomium sever for java with spring. No joda-time.

### DIFF
--- a/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomEntry.java
+++ b/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomEntry.java
@@ -1,0 +1,35 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import be.wegenenverkeer.atomium.japi.format.Content;
+import be.wegenenverkeer.atomium.japi.format.Link;
+import be.wegenenverkeer.atomium.japi.format.pub.AtomPubEntry;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * AtomEntry variant which is full java8, using java.time and readable.
+ *
+ * @param <T>
+ */
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "_type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = AtomPubEntry.class, name = "atom-pub"),
+        @JsonSubTypes.Type(value = AtomEntry.class, name = "atom")})
+@Data
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+public final class AtomEntry<T> {
+
+    private final String id;
+    private final LocalDateTime updated;
+    private final Content<T> content;
+    private List<Link> links = new ArrayList<>();
+
+}

--- a/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomiumServerException.java
+++ b/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomiumServerException.java
@@ -1,0 +1,38 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+/**
+ * Exception which indicates problems in the atomium server.
+ */
+public class AtomiumServerException extends RuntimeException {
+
+    /**
+     * Constructs a new runtime exception with the specified detail message.
+     * The cause is not initialized, and may subsequently be initialized by a
+     * call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for
+     * later retrieval by the {@link #getMessage()} method.
+     */
+    public AtomiumServerException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new runtime exception with the specified detail message and
+     * cause.  <p>Note that the detail message associated with
+     * {@code cause} is <i>not</i> automatically incorporated in
+     * this runtime exception's detail message.
+     *
+     * @param message the detail message (which is saved for later retrieval
+     * by the {@link #getMessage()} method).
+     * @param cause the cause (which is saved for later retrieval by the
+     * {@link #getCause()} method).  (A <tt>null</tt> value is
+     * permitted, and indicates that the cause is nonexistent or
+     * unknown.)
+     * @since 1.4
+     */
+    public AtomiumServerException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomiumServerSpring.java
+++ b/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomiumServerSpring.java
@@ -1,0 +1,7 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+/**
+ * No-op marker class for easy, type safe configuration of scanBasePackageClasses.
+ */
+public class AtomiumServerSpring {
+}

--- a/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomiumService.java
+++ b/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomiumService.java
@@ -1,0 +1,82 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+
+/**
+ * Atom feeds helper voor vaststellingen.
+ */
+@Component
+public class AtomiumService {
+
+    @Autowired
+    private AtomiumServiceHelper helper;
+
+    /**
+     * Haal de feed op. Voor een feed met cache headers, gebruik getCachedFeed.
+     * <p>
+     * Voordat de feed wordt opgehaald wordt "sync" opgeroepen in een aparte transactie.
+     *
+     * @param feedProvider entry provider
+     * @param page pagina
+     * @param count max number of items in page
+     * @param request request
+     * @param <E> Entry waarop de feed wordt gebaseerd
+     * @param <T> TO zoals deze in de feed moet verschijnen
+     * @return atom feed data
+     */
+    public <E, T> Response getFeed(FeedProvider<E, T> feedProvider, long page, long count, Request request) {
+        // safeguard, als je andere page sizes gebruikt dan ingesteld in de feedProvider kan je caching issues krijgen
+        if (feedProvider.getPageSize() != count) {
+            throw new AtomiumServerException(String.format("Pagina grootte komt niet overeen met verwachte waarde '%d', "
+                    + "de gebruikte link werd niet gegenereerd door Atom feed.", feedProvider.getPageSize()));
+        }
+
+        helper.sync(feedProvider);
+
+        return helper.getFeed(feedProvider, page, request, false);
+    }
+
+    /**
+     * Haal de feed met cache headers op.
+     * <p>
+     * Voordat de feed wordt opgehaald wordt "sync" opgeroepen in een aparte transactie.
+     * <p>
+     * De meest recente page wordt opgehaald.
+     *
+     * @param feedProvider entry provider
+     * @param request request
+     * @param <E> Entry waarop de feed wordt gebaseerd
+     * @param <T> TO zoals deze in de feed moet verschijnen
+     * @return atom feed data
+     */
+    public <E, T> Response getCurrentFeed(FeedProvider<E, T> feedProvider, Request request) {
+        helper.sync(feedProvider);
+
+        return helper.getFeed(feedProvider, detemineMostRecentPage(feedProvider), request, true);
+    }
+
+    /**
+     * Bepaal de meest recente page
+     *
+     * @param feedProvider entry provider
+     * @param <E> Entry waarop de feed wordt gebaseerd
+     * @param <T> TO zoals deze in de feed moet verschijnen
+     * @return meest recente page
+     */
+    <E, T> long detemineMostRecentPage(FeedProvider<E, T> feedProvider) {
+        long count = feedProvider.totalNumberOfEntries();
+        long pageSize = feedProvider.getPageSize();
+
+        long page = count / pageSize;
+
+        if (0 == count % pageSize && page > 0) {
+            page--;
+        }
+
+        return page;
+    }
+}

--- a/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomiumServiceHelper.java
+++ b/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/AtomiumServiceHelper.java
@@ -1,0 +1,144 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import be.wegenenverkeer.atomium.japi.format.Content;
+import be.wegenenverkeer.atomium.japi.format.Generator;
+import be.wegenenverkeer.atomium.japi.format.Link;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Zodat @Transactional correct wordt geproxied.
+ */
+@Component
+public class AtomiumServiceHelper {
+
+    @Value("${atomium.cacheDuration:2592000}") // default: cache for 30 days
+    private int cacheDuration;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    /**
+     * Update atom volgnummers (in aparte transactie).
+     *
+     * @param feedProvider feedProvider
+     * @param <E> Entry waarop de feed wordt gebaseerd
+     * @param <T> TO zoals deze in de feed moet verschijnen
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public <E, T> void sync(FeedProvider<E, T> feedProvider) {
+        feedProvider.sync();
+    }
+
+    /**
+     * Eigenlijke bepalen van de atom feed voor wijzigingen in de entries.
+     *
+     * @param feedProvider entry provider
+     * @param page pagina
+     * @param request request
+     * @param isCurrent wordt de feed opgevraagd langs "/"?
+     * @param <E> Entry waarop de feed wordt gebaseerd
+     * @param <T> TO zoals deze in de feed moet verschijnen
+     * @return atom feed data
+     */
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
+    public <E, T> Response getFeed(FeedProvider<E, T> feedProvider, long page, Request request, boolean isCurrent) {
+        // entries voor pagina bepalen (ééntje meer om te weten of er nog een volgende pagina is)
+        List<E> entriesForPage = feedProvider.getEntriesForPage(page);
+
+        if (entriesForPage.isEmpty()) {
+            return Response.status(404).entity("Pagina " + page + " niet gevonden.").build();
+        }
+
+        boolean pageComplete = entriesForPage.size() > feedProvider.getPageSize();
+        LocalDateTime updated = feedProvider.getTimestampForEntry(entriesForPage.get(0));
+
+        // updated time known, check/calculate eTag
+        CacheControl cc = new CacheControl();
+        cc.setMaxAge(cacheDuration);
+        Response.ResponseBuilder rb;
+        EntityTag etag = new EntityTag(Integer.toString(updated.hashCode()));
+        rb = request.evaluatePreconditions(etag); // Verify if it matched with etag available in http request
+        if (null != rb) { // rb is not null when eTag matched
+            return rb.cacheControl(cc).tag(etag).build();
+        }
+
+        // feed bouwen
+        Feed<T> feed = new Feed<>(
+                feedProvider.getFeedName(),
+                feedProvider.getFeedUrl(),
+                feedProvider.getFeedName(),
+                new Generator(feedProvider.getProviderName(), feedProvider.getFeedUrl(), feedProvider.getProviderVersion()),
+                updated
+        );
+
+        String pageUrl = "/" + page + '/' + feedProvider.getPageSize();
+
+        List<AtomEntry<T>> entries = entriesForPage.stream()
+                .map(entry -> toAtomEntry(entry, feedProvider))
+                .collect(toList());
+
+        feed.setEntries(entries);
+
+        List<Link> links = new ArrayList<>();
+        links.add(new Link("last", "/0/" + feedProvider.getPageSize()));
+        if (page >= 1) {
+            // volgens "REST in Practice" moet next en previous omgekeerd, voor atomium moet het in deze volgorde
+            links.add(new Link("next", "/" + (page - 1) + '/' + feedProvider.getPageSize()));
+        }
+        if (pageComplete) {
+            // volgens "REST in Practice" moet next en previous omgekeerd, voor atomium moet het in deze volgorde
+            links.add(new Link("previous", "/" + (page + 1) + '/' + feedProvider.getPageSize()));
+
+            // we hebben 1 element teveel opgehaald om een db call te besparen, maar die moet niet meegestuurd worden in deze page
+            feed.getEntries().remove(0);
+        }
+
+        links.add(new Link("self", pageUrl));
+        feed.setLinks(links);
+
+        // response opbouwen
+        try {
+            rb = Response.ok(mapper.writeValueAsString(feed));
+            if (!isCurrent && pageComplete) {
+                rb.cacheControl(cc); // cache result enkel als pagina volledig en niet via de "recent" URL opgeroepen. Zie figuur 7-2 in Rest In Practice.
+            }
+            rb.tag(etag);
+            return rb.build();
+        } catch (JsonProcessingException jpe) {
+            throw new AtomiumServerException("Kan stream niet converteren naar JSON.", jpe);
+        }
+    }
+
+    /**
+     * Entity to atom entry.
+     *
+     * @param entity entity
+     * @param feedProvider feedProvider
+     * @param <E> entity type
+     * @param <T> to type
+     * @return entity omgezet naar een TO
+     */
+    <E, T> AtomEntry<T> toAtomEntry(E entity, FeedProvider<E, T> feedProvider) {
+        return new AtomEntry<T>(
+                feedProvider.getUrnForEntry(entity),
+                feedProvider.getTimestampForEntry(entity),
+                new Content<>(feedProvider.toTo(entity), ""));
+    }
+
+}

--- a/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/Feed.java
+++ b/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/Feed.java
@@ -1,0 +1,31 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import be.wegenenverkeer.atomium.japi.format.Generator;
+import be.wegenenverkeer.atomium.japi.format.Link;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Feed zoals in Atomium, leesbaar en volgens Java 8 standaarden.
+ *
+ * @param <T>
+ */
+@Data
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+public final class Feed<T> {
+
+    private final String id;
+    private final String base;
+    private final String title;
+    private final Generator generator;
+    private final LocalDateTime updated;
+    private List<Link> links = new ArrayList<>();
+    private List<AtomEntry<T>> entries = new ArrayList<>();
+
+}

--- a/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/FeedProvider.java
+++ b/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/FeedProvider.java
@@ -1,0 +1,113 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Feed provider.
+ *
+ * @param <E> Entry waarop de feed wordt gebaseerd
+ * @param <T> TO zoals deze in de feed moet verschijnen
+ */
+public interface FeedProvider<E, T> {
+
+    /**
+     * Default page size.
+     */
+    long DEFAULT_PAGE_SIZE = 50;
+
+    /**
+     * URN prefix
+     */
+    String URN_ID = "urn:id:";
+
+    /**
+     * Haal entries op voor de gegeven page.
+     * <em>BELANGRIJK</em>:
+     * <ul>
+     * <li>Voorzie 1 extra entry. De extra entry is nodig om te bepalen of er een volgende pagina is. Op die manier hebben we maar 1 call naar de datastore nodig.</li>
+     * <li>Zet de nieuwste eerst! Atomium verwerkt de feed zoals een blog - de meest recente entry moet bovenaan staan.</li>
+     * </ul>
+     *
+     * @param pageNumber page nummer. Zero based.
+     * @return lijst van entries + <em>BELANGRIJK</em> 1 extra entry.
+     */
+    List<E> getEntriesForPage(long pageNumber);
+
+    /**
+     * Hoeveel entries in totaal?
+     *
+     * @return totaal aantal entries
+     */
+    long totalNumberOfEntries();
+
+    /**
+     * Zorg dat alle bestaande entries beschikbaar worden voor de feed. Kan gebruikt worden om de volgorde van de entries te garanderen.
+     */
+    void sync();
+
+    /**
+     * URN aanduiding voor elke entry in de feed.
+     *
+     * @param entry entry
+     * @return URN. <em>Opgelet</em>, moet beginnen met <code>urn:</code>
+     */
+    String getUrnForEntry(E entry);
+
+    /**
+     * Bereken de timestamp van de gegeven entry.
+     *
+     * @param entry entry
+     * @return timestamp
+     */
+    LocalDateTime getTimestampForEntry(E entry);
+
+    /**
+     * Zet entry om naar TO.
+     *
+     * @param entry entry
+     * @return TO
+     */
+    T toTo(E entry);
+
+    /**
+     * De gewenste feed URL.
+     *
+     * @return feed URL
+     */
+    String getFeedUrl();
+
+    /**
+     * Naam van de feed.
+     *
+     * @return naam van de feed
+     */
+    String getFeedName();
+
+    /**
+     * Geef de page size terug die gewenst is voor dit type feed.
+     *
+     * @return page size
+     */
+    default long getPageSize() {
+        return DEFAULT_PAGE_SIZE;
+    }
+
+    /**
+     * Geef de naam van de aanbieder.
+     *
+     * @return de naam van de aanbieder
+     */
+    default String getProviderName() {
+        return "DistrictCenter";
+    }
+
+    /**
+     * Geef de versie van de aanbieder.
+     *
+     * @return de versie van de aanbieder
+     */
+    default String getProviderVersion() {
+        return "1.0";
+    }
+}

--- a/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/PostgreSqlSyncQueryProvider.java
+++ b/modules/server-spring/src/main/java/be/wegenenverkeer/atomium/server/spring/PostgreSqlSyncQueryProvider.java
@@ -1,0 +1,70 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+/**
+ * Utility klasse om de SQL query op te bouwen om een een sync uit te voeren om het volgnummer in de atomium feed in the vullen voor een feed.
+ */
+public final class PostgreSqlSyncQueryProvider {
+
+    private PostgreSqlSyncQueryProvider() {
+        throw new UnsupportedOperationException("Constructor hidden.");
+    }
+
+    /**
+     * Bouw de SQL query die gebruikt kan worden om een volgnummer veld te zetten voor een tabel met events.
+     * Dat volgnummer zorgt voor een voorspelbare en consistente volgorde waarop de events in een atomium feed kopen.
+     * Gebruik van deze query voorkomt tussenvoegen van events en zorgt dat de events in verschillende thread kunnen geproduceerd worden.
+     *
+     * Deze query is gebouwd om atomic te zijn. De query bestaat uit 2 delen:
+     * 1) eerst worden de nieuwe atom_entries berekend via een common table expression.
+     *      In Postgres kan dat via het WITH statement.
+     *      https://www.postgresql.org/docs/current/static/queries-with.html
+     *
+     *      * Bepaal eerst de huidige hoogste waarde van de bestaande atom entries. Dat wordt opgeslagen als max_atom_entry
+     *      * Bepaal dan de lijst van items die nog geen atom_entry hebben, en orden die
+     *      * Vervolgens bereken je voor die lijst de nieuwe atom_entry waarde
+     *
+     * 2) dan wordt deze table gebruikt om ook effectief de tabel te updaten. In Postgres kan dat handig
+     *      via UPDATE ... FROM:
+     *      https://www.postgresql.org/docs/current/static/sql-update.html
+     *
+     * @param table naar van de tabel waarin het volgnummer zit, vb "oproep_event"
+     * @param sequenceField veld dat gebruikt wordt om de volgorde aan te duiden, vb "atom_entry"
+     * @param orderBy deel van de SQL query om de volgorde van de items te bepalen, vb "oproep_event.creation_time ASC"
+     * @return volledige SQL query om de sync uit te voeren
+     */
+    public static String syncQuery(String table, String sequenceField, String orderBy) {
+        return (""
+                + "WITH\n"
+                + "    max_atom_entry -- max bepalen, basis voor zetten volgnummer, -1 als nog niet gezet zodat teller bij 0 begint\n"
+                + "  AS ( SELECT coalesce(max(${table}.${sequence-field}), -1) max_atom_entry\n"
+                + "       FROM ${table}),\n"
+                + "    to_number -- lijst met aan te passen records, moet dit apart bepalen omdat volgorde anders fout is\n"
+                + "  AS (\n"
+                + "      SELECT\n"
+                + "        ${table}.id,\n"
+                //+ "        ${table}.creation_time,\n"
+                + "        max.max_atom_entry max_atom_entry\n"
+                + "      FROM ${table} CROSS JOIN max_atom_entry max\n"
+                + "      WHERE ${table}.${sequence-field} IS NULL\n"
+                + "      ORDER BY ${order-by}\n"
+                + "  ),\n"
+                + "    to_update -- lijst met wijzigingen opbouwen\n"
+                + "  AS (\n"
+                + "      SELECT\n"
+                + "        id,\n"
+                + "        (row_number()\n"
+                + "        OVER ()) + max_atom_entry new_value\n"
+                + "      FROM to_number\n"
+                + "      ORDER BY id ASC\n"
+                + "  )\n"
+                + "-- wijzigingen toepassen\n"
+                + "UPDATE ${table}\n"
+                + "SET ${sequence-field} = to_update.new_value\n"
+                + "FROM to_update\n"
+                + "WHERE ${table}.id = to_update.id;")
+                .replace("${table}", table)
+                .replace("${sequence-field}", sequenceField)
+                .replace("${order-by}", orderBy);
+    }
+
+}

--- a/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/AtomiumServiceHelperTest.java
+++ b/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/AtomiumServiceHelperTest.java
@@ -1,0 +1,349 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import be.vlaanderen.awv.dc.atomium.AtomEntry;
+import be.vlaanderen.awv.dc.atomium.Feed;
+import be.vlaanderen.awv.dc.atomium.TestFeedEntry;
+import be.vlaanderen.awv.dc.atomium.TestFeedEntryTo;
+import be.wegenenverkeer.atomium.japi.format.Link;
+import be.wegenenverkeer.common.resteasy.exception.NotFoundException;
+import be.wegenenverkeer.common.resteasy.json.RestJsonMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.Request;
+import javax.ws.rs.core.Response;
+
+import static java.util.Collections.emptyList;
+import static javax.servlet.http.HttpServletResponse.SC_OK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class AtomiumServiceHelperTest {
+
+    private static final int TEST_PAGE_SIZE = 2;
+    private static final LocalDateTime NOW = LocalDateTime.now();
+    public static final String TEST_FEED_NAME = "Test feed";
+    public static final String TEST_FEED_URL = "/test/feed/url";
+
+    @Spy
+    private RestJsonMapper mapper;
+
+    @InjectMocks
+    private AtomiumServiceHelper helper;
+
+    @Mock
+    Request request;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+    private List<TestFeedEntry> onvolledigeLijst = maakTestFeedEntries(TEST_PAGE_SIZE);
+    private List<TestFeedEntry> volledigeLijst = maakTestFeedEntries(TEST_PAGE_SIZE + 1);
+
+    @Test
+    public void sync() throws Exception {
+        TestFeedProvider testFeedProvider = mock(TestFeedProvider.class);
+
+        helper.sync(testFeedProvider);
+
+        verify(testFeedProvider, times(1)).sync();
+    }
+
+    @Test
+    public void geenEntriesVoorPageGevonden() throws Exception {
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(emptyList());
+
+        exception.expect(NotFoundException.class);
+        exception.expectMessage("Pagina 0 niet gevonden.");
+
+        helper.getFeed(testFeedProvider, 0, request, true);
+    }
+
+    @Test
+    public void etag_isDeHashVanDeTimestampVanDeEersteEntry() throws Exception {
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(volledigeLijst);
+
+        Response response = helper.getFeed(testFeedProvider, 0, request, true);
+
+        assertThat(response.getMetadata().getFirst("ETag")).isNotNull().isInstanceOf(EntityTag.class);
+
+        String hashcodeVanVoorlaatsteItem = Integer.toString(volledigeLijst.get(0).getTimestamp().hashCode());
+
+        assertThat(response.getMetadata().getFirst("ETag")).isEqualTo(EntityTag.valueOf(hashcodeVanVoorlaatsteItem));
+    }
+
+    @Test
+    public void etag_geenMatch() throws Exception {
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(volledigeLijst);
+        String hashcodeVanVoorlaatsteItem = Integer.toString(volledigeLijst.get(TEST_PAGE_SIZE - 1).getTimestamp().hashCode());
+        EntityTag etag = new EntityTag(hashcodeVanVoorlaatsteItem);
+
+        // wanneer de etag niet matcht wordt de feed opnieuw opgebouwd
+        when(request.evaluatePreconditions(etag)).thenReturn(null);
+
+        Response actualResponse = helper.getFeed(testFeedProvider, 0, request, true);
+
+        assertThat(actualResponse.getStatus()).isEqualTo(SC_OK); // echte response
+        verify(mapper, times(1)).writeValueAsString(any()); // nieuwe feed schrijven
+    }
+
+    @Test
+    public void etag_match() throws Exception {
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(volledigeLijst);
+        String hashcodeVanVoorlaatsteItem = Integer.toString(volledigeLijst.get(0).getTimestamp().hashCode());
+        EntityTag etag = new EntityTag(hashcodeVanVoorlaatsteItem);
+
+        Response expectedResponse = mock(Response.class);
+
+        // wanneer de etag matcht wordt deze response builder gebruikt
+        Response.ResponseBuilder responseBuilder = mock(Response.ResponseBuilder.class);
+        when(responseBuilder.cacheControl(any())).thenReturn(responseBuilder);
+        when(responseBuilder.tag(etag)).thenReturn(responseBuilder);
+        when(responseBuilder.build()).thenReturn(expectedResponse);
+        when(request.evaluatePreconditions(etag)).thenReturn(responseBuilder);
+
+        Response actualResponse = helper.getFeed(testFeedProvider, 0, request, true);
+
+        assertThat(actualResponse).isEqualTo(expectedResponse);
+        verify(responseBuilder, times(1)).build();
+        verify(mapper, never()).writeValueAsString(any()); // geen nieuwe feed schrijven
+    }
+
+    @Test
+    public void indienCurrentPage_nietGecached() throws Exception {
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(onvolledigeLijst);
+
+        Response response = helper.getFeed(testFeedProvider, 0, request, true);
+
+        assertThat(response.getMetadata().getFirst("Cache-Control")).isNull();
+    }
+
+    @Test
+    public void indienRecentPageNietVolledig_nietGecached() throws Exception {
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(onvolledigeLijst);
+
+        Response response = helper.getFeed(testFeedProvider, 0, request, false);
+
+        assertThat(response.getMetadata().getFirst("Cache-Control")).isNull();
+    }
+
+    @Test
+    public void indienRecentPageWelVolledig_welGecached() throws Exception {
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(volledigeLijst);
+
+        Response response = helper.getFeed(testFeedProvider, 0, request, false);
+
+        assertThat(response.getMetadata().getFirst("Cache-Control")).isNotNull();
+        assertThat(response.getMetadata().getFirst("Cache-Control").toString())
+                .isEqualTo("no-transform, max-age=0"); // max-age=0, want @Value wordt niet geïnitialiseerd in unit tests
+    }
+
+    @Test
+    public void feedWordtOpgebouwd_metadata() throws Exception {
+        Feed<TestFeedEntryTo> feed = getFeed(volledigeLijst);
+
+        assertThat(feed.getId()).isEqualTo(TEST_FEED_NAME);
+        assertThat(feed.getBase()).isEqualTo(TEST_FEED_URL);
+        assertThat(feed.getTitle()).isEqualTo(TEST_FEED_NAME);
+        assertThat(feed.getGenerator().getText()).isEqualTo("DistrictCenter");
+        assertThat(feed.getGenerator().getUri()).isEqualTo(TEST_FEED_URL);
+        assertThat(feed.getGenerator().getVersion()).isEqualTo("1.0");
+    }
+
+    @Test
+    public void feedWordtOpgebouwd_onvolledigePage() throws Exception {
+        List<TestFeedEntry> teTestenLijst = new ArrayList<>(onvolledigeLijst);
+        int teTestenLijstSize = teTestenLijst.size();
+
+        Feed<TestFeedEntryTo> feed = getFeed(teTestenLijst);
+
+        String[] expectedIds = teTestenLijst.stream()
+                .map(entry -> "urn:id:" + entry.getId())
+                .toArray(String[]::new);
+
+        assertThat(feed.getEntries()).hasSize(teTestenLijstSize).extracting("id").containsExactly(expectedIds);
+    }
+
+    @Test
+    public void feedWordtOpgebouwd_volledigePage() throws Exception {
+        // de code gaat er van uit dat je een page + 1 geeft, dat is een efficiente manier om te weten of de page volledig is
+        // als je immers page size + 1 items krijgt weet je dat er nog elementen volgen
+        List<TestFeedEntry> teTestenLijst = new ArrayList<>(volledigeLijst);
+        int teTestenLijstSize = teTestenLijst.size();
+
+        Feed<TestFeedEntryTo> feed = getFeed(teTestenLijst);
+
+        String[] expectedIds = teTestenLijst.subList(1, teTestenLijst.size())
+                .stream()
+                .map(entry -> "urn:id:" + entry.getId())
+                .toArray(String[]::new);
+
+        assertThat(feed.getEntries()).hasSize(teTestenLijstSize - 1).extracting("id").containsExactly(expectedIds);
+    }
+
+    @Test
+    public void feedWordtOpgebouwd_volledigePageIsVolledigeLijstMinDeLaatste() throws Exception {
+        // de code gaat er van uit dat je een page + 1 geeft, dat is een efficiente manier om te weten of de page volledig is
+        // als je immers page size + 1 items krijgt weet je dat er nog elementen volgen
+        Feed<TestFeedEntryTo> feed = getFeed(volledigeLijst);
+
+        List<TestFeedEntry> lijstClone = new ArrayList<>(volledigeLijst);
+        String[] expectedIds = lijstClone.subList(1, lijstClone.size()).stream()
+                .map(entry -> "urn:id:" + entry.getId())
+                .toArray(String[]::new);
+
+        assertThat(feed.getEntries()).hasSize(volledigeLijst.size() - 1).extracting("id").containsExactly(expectedIds);
+    }
+
+    @Test
+    public void feedWordtOpgebouwd_linksVoorEenVolledigePage0() throws Exception {
+        Feed<TestFeedEntryTo> feed = getFeed(volledigeLijst);
+
+        assertThat(feed.getLinks()).isNotEmpty();
+        assertThat(feed.getLinks()).extracting("rel").containsExactly("last", "previous", "self");
+
+        assertThat(getLink(feed.getLinks(), "self").getHref()).isEqualTo("/0/2");
+        assertThat(getLink(feed.getLinks(), "last").getHref()).isEqualTo("/0/2");
+        assertThat(getLink(feed.getLinks(), "previous").getHref()).isEqualTo("/1/2");  // previous is de volgende pagina :-/
+    }
+
+
+    @Test
+    public void feedWordtOpgebouwd_linksVoorEenVolledigePage1() throws Exception {
+        Feed<TestFeedEntryTo> feed = getFeed(volledigeLijst, 1);
+
+        assertThat(feed.getLinks()).isNotEmpty();
+        assertThat(feed.getLinks()).extracting("rel").containsExactly("last", "next", "previous", "self");
+
+        assertThat(getLink(feed.getLinks(), "self").getHref()).isEqualTo("/1/2");
+        assertThat(getLink(feed.getLinks(), "last").getHref()).isEqualTo("/0/2");
+        assertThat(getLink(feed.getLinks(), "next").getHref()).isEqualTo("/0/2"); // next is de vorige pagina :-/
+        assertThat(getLink(feed.getLinks(), "previous").getHref()).isEqualTo("/2/2");  // previous is de volgende pagina :-/
+    }
+
+    @Test
+    public void feedWordtOpgebouwd_linksVoorEenOnvolledigePage() throws Exception {
+        Feed<TestFeedEntryTo> feed = getFeed(onvolledigeLijst);
+
+        assertThat(feed.getLinks()).isNotEmpty();
+        assertThat(feed.getLinks()).extracting("rel").containsExactly("last", "self");
+
+        assertThat(getLink(feed.getLinks(), "self").getHref()).isEqualTo("/0/2");
+        assertThat(getLink(feed.getLinks(), "last").getHref()).isEqualTo("/0/2");
+    }
+
+    @Test
+    public void toAtomEntry() throws Exception {
+        int id = 42;
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(onvolledigeLijst);
+        AtomEntry<TestFeedEntryTo> atomEntry = helper.toAtomEntry(new TestFeedEntry(id, NOW), testFeedProvider);
+
+        assertThat(atomEntry.getId()).isEqualTo("urn:id:" + id);
+    }
+
+    private Link getLink(List<Link> links, String name) {
+        Optional<Link> link = links.stream().filter(current -> current.getRel().equals(name)).findFirst();
+        assertThat(link).isPresent();
+        return link.get();
+    }
+
+    private Feed<TestFeedEntryTo> getFeed(List<TestFeedEntry> lijst) throws Exception {
+        return getFeed(lijst, 0);
+    }
+
+    private Feed<TestFeedEntryTo> getFeed(List<TestFeedEntry> lijst, int page) throws Exception {
+        TestFeedProvider testFeedProvider = new TestFeedProvider();
+        testFeedProvider.setEntriesForPage(lijst);
+
+        Response response = helper.getFeed(testFeedProvider, page, request, false);
+        return mapper.readValue(response.getEntity().toString(), new TypeReference<Feed<TestFeedEntryTo>>() {
+        });
+    }
+
+    private List<TestFeedEntry> maakTestFeedEntries(int testPageSize) {
+        return IntStream.rangeClosed(1, testPageSize)
+                .mapToObj(integer -> new TestFeedEntry(testPageSize + 42 - integer, NOW.minusDays(integer)))
+                .collect(Collectors.toList());
+    }
+
+    public class TestFeedProvider implements FeedProvider<TestFeedEntry, TestFeedEntryTo> {
+        private List<TestFeedEntry> entries;
+
+        @Override
+        public List<TestFeedEntry> getEntriesForPage(long pageNumber) {
+            return entries;
+        }
+
+        @Override
+        public long totalNumberOfEntries() {
+            return 42;
+        }
+
+        public void setEntriesForPage(List<TestFeedEntry> entries) {
+            this.entries = entries;
+        }
+
+        @Override
+        public void sync() {
+            // no-op
+        }
+
+        @Override
+        public String getUrnForEntry(TestFeedEntry entry) {
+            return URN_ID + entry.getId();
+        }
+
+        @Override
+        public LocalDateTime getTimestampForEntry(TestFeedEntry entry) {
+            return entry.getTimestamp();
+        }
+
+        @Override
+        public TestFeedEntryTo toTo(TestFeedEntry entry) {
+            return new TestFeedEntryTo(entry.getId());
+        }
+
+        @Override
+        public String getFeedUrl() {
+            return TEST_FEED_URL;
+        }
+
+        @Override
+        public String getFeedName() {
+            return TEST_FEED_NAME;
+        }
+
+        @Override
+        public long getPageSize() {
+            return TEST_PAGE_SIZE;
+        }
+    }
+}

--- a/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/AtomiumServiceTest.java
+++ b/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/AtomiumServiceTest.java
@@ -1,0 +1,118 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import be.vlaanderen.awv.dc.atomium.TestFeedEntry;
+import be.vlaanderen.awv.dc.atomium.TestFeedEntryTo;
+import be.wegenenverkeer.common.resteasy.exception.ServiceException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import javax.ws.rs.core.Request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AtomiumServiceTest {
+
+    private static final LocalDateTime NOW = LocalDateTime.now();
+    private static final long PAGE_SIZE = 42;
+
+    @Mock
+    private AtomiumServiceHelper helper;
+
+    @InjectMocks
+    private AtomiumService atomiumService;
+
+    @Mock
+    private Request request;
+
+    @Mock
+    private FeedProvider<TestFeedEntry, TestFeedEntryTo> mockFeedProvider;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void getFeed() throws Exception {
+        int page = 0;
+
+        when(mockFeedProvider.getEntriesForPage(0)).thenReturn(Collections.singletonList(new TestFeedEntry(42, NOW)));
+        when(mockFeedProvider.getTimestampForEntry(any())).thenReturn(LocalDateTime.MIN);
+        when(mockFeedProvider.getUrnForEntry(any())).thenReturn("THE URN");
+        when(mockFeedProvider.toTo(any())).thenReturn(new TestFeedEntryTo());
+        when(mockFeedProvider.getPageSize()).thenReturn(PAGE_SIZE);
+
+        atomiumService.getFeed(mockFeedProvider, page, PAGE_SIZE, request);
+
+        verify(helper, times(1)).sync(mockFeedProvider);
+        verify(helper, times(1)).getFeed(mockFeedProvider, page, request, false);
+    }
+
+    @Test
+    public void getFeed_foutePagesize() throws Exception {
+        int page = 0;
+
+        when(mockFeedProvider.getEntriesForPage(0)).thenReturn(Collections.singletonList(new TestFeedEntry(42, NOW)));
+        when(mockFeedProvider.getTimestampForEntry(any())).thenReturn(LocalDateTime.MIN);
+        when(mockFeedProvider.getUrnForEntry(any())).thenReturn("THE URN");
+        when(mockFeedProvider.toTo(any())).thenReturn(new TestFeedEntryTo());
+        when(mockFeedProvider.getPageSize()).thenReturn(PAGE_SIZE);
+
+        exception.expect(ServiceException.class);
+        exception.expectMessage(String.format("Pagina grootte komt niet overeen met verwachte waarde '%d', de gebruikte link werd niet gegenereerd door Atom feed.", PAGE_SIZE));
+
+        atomiumService.getFeed(mockFeedProvider, page, PAGE_SIZE + 1, request);
+    }
+
+    @Test
+    public void getCurrentFeed() throws Exception {
+        double factor = 3;
+
+        when(mockFeedProvider.getEntriesForPage(0)).thenReturn(Collections.singletonList(new TestFeedEntry(42, NOW)));
+        when(mockFeedProvider.getTimestampForEntry(any())).thenReturn(LocalDateTime.MIN);
+        when(mockFeedProvider.getUrnForEntry(any())).thenReturn("THE URN");
+        when(mockFeedProvider.toTo(any())).thenReturn(new TestFeedEntryTo());
+        when(mockFeedProvider.totalNumberOfEntries()).thenReturn(Double.valueOf(PAGE_SIZE * factor).longValue());
+        when(mockFeedProvider.getPageSize()).thenReturn(PAGE_SIZE);
+
+        atomiumService.getCurrentFeed(mockFeedProvider, request);
+
+        verify(helper, times(1)).sync(mockFeedProvider);
+        verify(helper, times(1)).getFeed(mockFeedProvider, atomiumService.detemineMostRecentPage(mockFeedProvider), request, true);
+    }
+
+    @Test
+    public void detemineMostRecentPage() {
+        double factor = 3.2;
+
+        when(mockFeedProvider.totalNumberOfEntries()).thenReturn(Double.valueOf(PAGE_SIZE * factor).longValue());
+        when(mockFeedProvider.getPageSize()).thenReturn(PAGE_SIZE);
+
+        long actual = atomiumService.detemineMostRecentPage(mockFeedProvider);
+
+        assertThat(actual).isEqualTo(Double.valueOf(factor).intValue());
+    }
+
+    @Test
+    public void detemineMostRecentPage_countGelijkAanVeelvoudPageSize() {
+        double factor = 3;
+
+        when(mockFeedProvider.totalNumberOfEntries()).thenReturn(Double.valueOf(PAGE_SIZE * factor).longValue());
+        when(mockFeedProvider.getPageSize()).thenReturn(PAGE_SIZE);
+
+        long actual = atomiumService.detemineMostRecentPage(mockFeedProvider);
+
+        assertThat(actual).isEqualTo(Double.valueOf(factor - 1).intValue());
+    }
+
+}

--- a/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/PostgreSqlSyncQueryProviderTest.java
+++ b/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/PostgreSqlSyncQueryProviderTest.java
@@ -1,0 +1,42 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PostgreSqlSyncQueryProviderTest {
+
+    @Test
+    public void syncQuery() throws Exception {
+        assertThat(PostgreSqlSyncQueryProvider.syncQuery("oproep_event", "atom_entry", "oproep_event.creation_time ASC")).isEqualTo(""
+                + "WITH\n"
+                + "    max_atom_entry -- max bepalen, basis voor zetten volgnummer, -1 als nog niet gezet zodat teller bij 0 begint\n"
+                + "  AS ( SELECT coalesce(max(oproep_event.atom_entry), -1) max_atom_entry\n"
+                + "       FROM oproep_event),\n"
+                + "    to_number -- lijst met aan te passen records, moet dit apart bepalen omdat volgorde anders fout is\n"
+                + "  AS (\n"
+                + "      SELECT\n"
+                + "        oproep_event.id,\n"
+                //+ "        oproep_event.creation_time,\n"
+                + "        max.max_atom_entry max_atom_entry\n"
+                + "      FROM oproep_event CROSS JOIN max_atom_entry max\n"
+                + "      WHERE oproep_event.atom_entry IS NULL\n"
+                + "      ORDER BY oproep_event.creation_time ASC\n"
+                + "  ),\n"
+                + "    to_update -- lijst met wijzigingen opbouwen\n"
+                + "  AS (\n"
+                + "      SELECT\n"
+                + "        id,\n"
+                + "        (row_number()\n"
+                + "        OVER ()) + max_atom_entry new_value\n"
+                + "      FROM to_number\n"
+                + "      ORDER BY id ASC\n"
+                + "  )\n"
+                + "-- wijzigingen toepassen\n"
+                + "UPDATE oproep_event\n"
+                + "SET atom_entry = to_update.new_value\n"
+                + "FROM to_update\n"
+                + "WHERE oproep_event.id = to_update.id;");
+    }
+
+}

--- a/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/TestFeedEntry.java
+++ b/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/TestFeedEntry.java
@@ -1,0 +1,13 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@RequiredArgsConstructor
+public class TestFeedEntry {
+    private final long id;
+    private final LocalDateTime timestamp;
+}

--- a/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/TestFeedEntryTo.java
+++ b/modules/server-spring/src/main/test/java/be/wegenenverkeer/atomium/server/spring/TestFeedEntryTo.java
@@ -1,0 +1,14 @@
+package be.wegenenverkeer.atomium.server.spring;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@NoArgsConstructor(force = true)
+@RequiredArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TestFeedEntryTo {
+    private final long id;
+}

--- a/project/AtomiumBuild.scala
+++ b/project/AtomiumBuild.scala
@@ -66,7 +66,7 @@ object AtomiumBuild extends Build with BuildSettings {
   lazy val clientJavaModule = {
 
     val mainDeps = Seq(slf4j, commonsIo, rxhttpclient)
-    val testDeps = Seq(junit, wiremock, mockitoCore, assertJ, jfakerMockito, junitInterface)
+    val testDeps = Seq(junit, wiremock, mockitoCore, assertJ, junitInterface)
 
     project("client-java")
       .settings(libraryDependencies ++= mainDeps ++ testDeps)
@@ -112,6 +112,20 @@ object AtomiumBuild extends Build with BuildSettings {
       .settings(crossScalaVersions := Seq("2.10.4", "2.11.8"))
       .dependsOn(formatModule)
 
+
+  //----------------------------------------------------------------
+  lazy val serverSpringModule = {
+
+    val mainDeps = Seq(slf4j, lombok, springContext, springTx, jaxRsApi)
+    val testDeps = Seq(junit, wiremock, mockitoCore, assertJ, junitInterface)
+
+    project("server-spring")
+      .settings(libraryDependencies ++= mainDeps ++ testDeps)
+      .settings( autoScalaLibrary := false )
+      .settings(crossPaths := false)
+      .dependsOn(javaFormatModule)
+
+  }
 
   //----------------------------------------------------------------
   lazy val serverMongoModule = {
@@ -199,6 +213,7 @@ object AtomiumBuild extends Build with BuildSettings {
     clientScalaModule,
     clientJavaModule,
     serverModule,
+    serverSpringModule,
     serverMongoModule,
     serverSlickModule,
     serverJdbcModule,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -43,12 +43,14 @@ object Dependencies {
   val jacksonDatabind   = "com.fasterxml.jackson.core"      %   "jackson-databind"        % "2.4.3"
   val jacksonJoda       = "com.fasterxml.jackson.datatype"  %   "jackson-datatype-joda"   % "2.4.3"
   val rxhttpclient      = "be.wegenenverkeer"               %   "rxhttpclient-java"       % "0.4.0"
-
+  val lombok            = "org.projectlombok"               %   "lombok"                  % "1.16.10" % "provided"
+  val springContext     = "org.springframework"             %   "spring-context"          % "4.2.0.RELEASE"
+  val springTx          = "org.springframework"             %   "spring-tx"               % "4.2.0.RELEASE"
+  val jaxRsApi          = "org.jboss.spec.javax.ws.rs"      %   "jboss-jaxrs-api_2.0_spec" % "1.0.0.Final"
 
   val slf4j             = "org.slf4j"                       %   "slf4j-api"               % "1.7.6"
   val mockitoCore       = "org.mockito"                     %   "mockito-core"            % "1.9.5"   % "test"
   val assertJ           = "org.assertj"                     %   "assertj-core"            % "1.5.0"   % "test"
-  val jfakerMockito     = "be.eliwan"                       %   "jfaker-mockito"          % "0.1"     % "test"
   val commonsIo         = "commons-io"                      %   "commons-io"              % "2.4"     % "test"
 
 


### PR DESCRIPTION
New server-spring module which allows the user to easily build a java8 compatible (using java.time instead of joda-time). This can easily be integrated with spring (annotations provided).
