### PR TITLE
Add a "recovery strategy" to the pagefetcher.

### DIFF
--- a/modules/client-java/src/main/java/be/wegenenverkeer/atomium/client/AtomiumFeed.java
+++ b/modules/client-java/src/main/java/be/wegenenverkeer/atomium/client/AtomiumFeed.java
@@ -86,7 +86,12 @@ public class AtomiumFeed<E> {
                         .flatMap(this::applyRetryStrategy)
                         .flatMap(delay -> Flowable.just(1).delay(delay, TimeUnit.MILLISECONDS))
                 )
-                .doAfterSuccess(page -> this.retryCount = 0);
+                .doAfterSuccess(page -> {
+                    if (this.retryCount > 0) {
+                        pageFetcher.getRecoveryStrategy().apply(this.retryCount);
+                    }
+                    this.retryCount = 0;
+                });
     }
 
     private Flowable<Long> applyRetryStrategy(Throwable throwable) {

--- a/modules/client-java/src/main/java/be/wegenenverkeer/atomium/client/PageFetcher.java
+++ b/modules/client-java/src/main/java/be/wegenenverkeer/atomium/client/PageFetcher.java
@@ -9,4 +9,5 @@ public interface PageFetcher<E> {
     void close();
     Class<E> getEntryTypeMarker();
     RetryStrategy getRetryStrategy();
+    RecoveryStrategy getRecoveryStrategy();
 }

--- a/modules/client-java/src/main/java/be/wegenenverkeer/atomium/client/RecoveryStrategy.java
+++ b/modules/client-java/src/main/java/be/wegenenverkeer/atomium/client/RecoveryStrategy.java
@@ -1,0 +1,15 @@
+package be.wegenenverkeer.atomium.client;
+
+/**
+ *  A functional interface for recovery strategies
+ *
+ */
+public interface RecoveryStrategy {
+
+    /**
+     * Applies a recovery an <code>Observable</code> of feed items. Will be called when the atomium feed's page-fetcher manages
+     * to fetch a page again after a period of retry'ing.
+     */
+    void apply(int retriesBeforeSuccess);
+
+}


### PR DESCRIPTION
This works analogous to the RetryStrategy and allows the user to hook into the flow when a pagefetcher recovers from a period of retrying.

If a user wants to keep track the retryCount for their own health monitoring, this is needed.